### PR TITLE
Added post build action

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,15 @@ If you are merging into your target branch, you might want Jenkins to do a new b
 
 ##Rerun test builds
 
-
 If you want to rerun pull request test, write *“test this please”* comment to your pull request.
 
 
+## Post Build Comment
+
+It is possible to add a post build action that gives the option to post additional information to Stash when a build has been either successful or failed.
+These comments can contain environment variables that will be translated when posted to Stash.
+
+This feature can be used to post for instance a url to the deployed application or code coverage at a successful build and why the build failed like what tests that did not pass.
 
 ##Copyright
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -57,6 +57,14 @@ public class StashBuilds {
             buildUrl = rootUrl + build.getUrl();
         }
         repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
-        repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(), cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl, build.getNumber());
+
+        StashPostBuildCommentAction comments = build.getAction(StashPostBuildCommentAction.class);
+        String additionalComment = "";
+        if(comments != null) {
+            additionalComment = "\n\n" +
+                    (result == Result.SUCCESS ? comments.getBuildSuccessfulComment() : comments.getBuildFailedComment());
+        }
+
+        repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(), cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl, build.getNumber(), additionalComment);
     }
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
@@ -1,0 +1,101 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import hudson.Util;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class StashPostBuildComment extends Notifier {
+    private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
+    private String buildSuccessfulComment;
+    private String buildFailedComment;
+
+    @DataBoundConstructor
+    public StashPostBuildComment(String buildSuccessfulComment, String buildFailedComment) {
+        this.buildSuccessfulComment = buildSuccessfulComment;
+        this.buildFailedComment = buildFailedComment;
+    }
+
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.BUILD;
+    }
+
+    public String getBuildSuccessfulComment() {
+        return buildSuccessfulComment;
+    }
+
+    public void setBuildSuccessfulComment(String buildSuccessfulComment) {
+        this.buildSuccessfulComment = buildSuccessfulComment;
+    }
+
+    public String getBuildFailedComment() {
+        return buildFailedComment;
+    }
+
+    public void setBuildFailedComment(String buildFailedComment) {
+        this.buildFailedComment = buildFailedComment;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+
+        try {
+          build.addAction(new StashPostBuildCommentAction(
+            Util.fixEmptyAndTrim(build.getEnvironment(listener).expand(buildSuccessfulComment)),
+            Util.fixEmptyAndTrim(build.getEnvironment(listener).expand(buildFailedComment))
+          ));
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Unable to parse comments", e);
+            listener.finished(Result.FAILURE);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public BuildStepDescriptor<Publisher> getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    @Extension
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+    public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+        public DescriptorImpl() {
+            super(StashPostBuildComment.class);
+        }
+
+        @Override
+        public StashPostBuildComment newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return req.bindJSON(StashPostBuildComment.class, formData);
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            // Requires that the Build Trigger is set or else nothing is posted.
+            // We would like that the Post Build Comment option should not be visible when
+            // the build trigger is not present.
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Stash Pull Request Builder - Post Build Comment";
+        }
+    }
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildCommentAction.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildCommentAction.java
@@ -1,0 +1,21 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import hudson.model.InvisibleAction;
+
+public class StashPostBuildCommentAction extends InvisibleAction {
+    private final String buildSuccessfulComment;
+    private final String buildFailedComment;
+
+    public StashPostBuildCommentAction(String buildSuccessfulComment, String buildFailedComment) {
+        this.buildSuccessfulComment = buildSuccessfulComment;
+        this.buildFailedComment = buildFailedComment;
+    }
+
+    public String getBuildSuccessfulComment() {
+        return this.buildSuccessfulComment;
+    }
+
+    public String getBuildFailedComment() {
+        return this.buildFailedComment;
+    }
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -97,12 +97,14 @@ public class StashRepository {
         this.client.deletePullRequestComment(pullRequestId, commentId);
     }
 
-    public void postFinishedComment(String pullRequestId, String sourceCommit,  String destinationCommit, boolean success, String buildUrl, int buildNumber) {
+    public void postFinishedComment(String pullRequestId, String sourceCommit,  String destinationCommit, boolean success, String buildUrl, int buildNumber, String additionalComment) {
         String message = BUILD_FAILURE_COMMENT;
         if (success){
             message = BUILD_SUCCESS_COMMENT;
         }
         String comment = String.format(BUILD_FINISH_SENTENCE, builder.getProject().getDisplayName(), sourceCommit, destinationCommit, message, buildUrl, buildNumber);
+
+        comment = comment.concat(additionalComment);
 
         this.client.postPullRequestComment(pullRequestId, comment);
     }

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment/config.jelly
@@ -1,0 +1,8 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="Comment when build was successful" field="buildSuccessfulComment">
+        <f:textarea/>
+  </f:entry>
+  <f:entry title="Comment when build failed" field="buildFailedComment">
+        <f:textarea/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment/help-buildFailedComment.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment/help-buildFailedComment.html
@@ -1,0 +1,3 @@
+<div>
+    Comment that will be added to what is posted to Stash when the build <strong>failed</strong>. Possible to use environment variables like <em>${BUILD_NUMBER}</em>.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment/help-buildSuccessfulComment.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment/help-buildSuccessfulComment.html
@@ -1,0 +1,3 @@
+<div>
+    Comment that will be added to what is posted to Stash when the build has been <strong>successful</strong>. Possible to use environment variables like <em>${BUILD_NUMBER}</em>.
+</div>


### PR DESCRIPTION
Makes it possible to add additional comments to what is sent to Stash after a build.

I found no way to make the post build action not be available when the build trigger has not been selected, any input here?