### PR TITLE
Use Git SCM as provider for stash pull request builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ By default it will only accept pull requests that match the target branch specif
 If you are merging into your target branch, you might want Jenkins to do a new build of the Pull Request when the target branch changes.
 - There is a checkbox that says, "Rebuild if destination branch changes?" which enables this check.
 
+##Notify Stash instance
+
+If you have enabled the 'Notify Stash Instance' Post-build Action and also enabled the 'Merge before build' extension you need to add '${pullRequestCommit}' as Commit SHA-1. Otherwise you'll notify Stash with the commit hash resulting from the merge which isn't known to Stash (since it's merged locally).
 
 ##Rerun test builds
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,14 @@ This plugin was inspired by the GitHub & BitBucket pull request builder plugins.
 
 - Create a new job
 - Select Git SCM
-- Add Repository URL as bellow
-  - git@myStashHost.com:${projectCode}/${repositoryName}.git
+- Add Repository URL
+	- Choose credentials (will be used by trigger)
+	- Set refspec to: +refs/pull-requests/*:refs/remotes/origin/pr/*
 - In Branch Specifier, type as bellow
-  - */${sourceBranch}
+  - ${pullRequest}
 - Under Build Triggers, check Stash Pull Request Builder
 - In Cron, enter crontab for this job.
   - e.g. every minute: * * * * *
-- In Stash BasicAuth Username - Stash username like jenkins-buildbot
-- In Stash BasicAuth Password - Jenkins Build Bot password
-- Supply project code (this is the abbreviated project code, e.g. PRJ)
-- Supply Repository Name (e.g. myRepo)
 - Save to preserve your changes
 
 ##Merge the Pull Request's Source Branch into the Target Branch Before Building
@@ -40,9 +37,10 @@ You may want Jenkins to attempt to merge your PR before doing the build -- this 
 - Follow the steps above in "Creating a Job"
 - In the "Source Code Management" > "Git" > "Additional Behaviors" section, click "Add" > "Merge Before Building"
 - In "Name of Repository" put "origin" (or, if not using default name, use your remote repository's name. Note: unlike in the main part of the Git Repository config, you cannot leave this item blank for "default".)
-- In "Branch to merge to" put "${targetBranch}" 
+- In "Branch to merge to" put the target branch you want to merge to 
 - Note that as long as you don't push these changes to your remote repository, the merge only happens in your local repository.
 
+By default it will only accept pull requests that match the target branch specified as target branch in the 'Merge before build' extension. You can choose to disable this or choose an custom filter to limit the number of pull requests being verified. Both options are available in the advanced tab.
 
 If you are merging into your target branch, you might want Jenkins to do a new build of the Pull Request when the target branch changes.
 - There is a checkbox that says, "Rebuild if destination branch changes?" which enables this check.

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -4,9 +4,11 @@ import antlr.ANTLRException;
 import hudson.Extension;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
+import hudson.plugins.git.GitSCM;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import net.sf.json.JSONObject;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -23,13 +25,10 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
     private final String projectPath;
     private final String cron;
-    private final String stashHost;
-    private final String username;
-    private final String password;
-    private final String projectCode;
-    private final String repositoryName;
+    private final String targetBranchFilter;
     private final String ciSkipPhrases;
     private final String ciBuildPhrases;
+    private final boolean checkMergeBeforeBuild;
     private final boolean checkDestinationCommit;
     private final boolean checkMergeable;
     private final boolean checkNotConflicted;
@@ -44,12 +43,9 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     public StashBuildTrigger(
             String projectPath,
             String cron,
-            String stashHost,
-            String username,
-            String password,
-            String projectCode,
-            String repositoryName,
+            String targetBranchFilter,
             String ciSkipPhrases,
+            boolean checkMergeBeforeBuild,
             boolean checkDestinationCommit,
             boolean checkMergeable,
             boolean checkNotConflicted,
@@ -59,21 +55,14 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         super(cron);
         this.projectPath = projectPath;
         this.cron = cron;
-        this.stashHost = stashHost;
-        this.username = username;
-        this.password = password;
-        this.projectCode = projectCode;
-        this.repositoryName = repositoryName;
+        this.targetBranchFilter = targetBranchFilter;
         this.ciSkipPhrases = ciSkipPhrases;
         this.ciBuildPhrases = ciBuildPhrases == null ? "test this please" : ciBuildPhrases;
+        this.checkMergeBeforeBuild = checkMergeBeforeBuild;
         this.checkDestinationCommit = checkDestinationCommit;
         this.checkMergeable = checkMergeable;
         this.checkNotConflicted = checkNotConflicted;
         this.onlyBuildOnComment = onlyBuildOnComment;
-    }
-
-    public String getStashHost() {
-        return stashHost;
     }
 
     public String getProjectPath() {
@@ -84,23 +73,11 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         return this.cron;
     }
 
-    public String getUsername() {
-        return username;
-    }
+    public String getTargetBranchFilter() {
+		return targetBranchFilter;
+	}
 
-    public String getPassword() {
-        return password;
-    }
-
-    public String getProjectCode() {
-        return projectCode;
-    }
-
-    public String getRepositoryName() {
-        return repositoryName;
-    }
-
-    public String getCiSkipPhrases() {
+	public String getCiSkipPhrases() {
         return ciSkipPhrases;
     }
 
@@ -108,13 +85,20 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         return ciBuildPhrases == null ? "test this please" : ciBuildPhrases;
     }
 
-    public boolean getCheckDestinationCommit() {
+    public boolean isCheckMergeBeforeBuild() {
+		return checkMergeBeforeBuild;
+	}
+
+	public boolean getCheckDestinationCommit() {
     	return checkDestinationCommit;
     }
 
     @Override
     public void start(AbstractProject<?, ?> project, boolean newInstance) {
         try {
+        	if (!(project.getScm() instanceof GitSCM))
+        		throw new IllegalStateException("No git SCM defined");
+        	
             this.stashPullRequestsBuilder = StashPullRequestsBuilder.getBuilder();
             this.stashPullRequestsBuilder.setProject(project);
             this.stashPullRequestsBuilder.setTrigger(this);
@@ -126,8 +110,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         super.start(project, newInstance);
     }
 
-    public static StashBuildTrigger getTrigger(AbstractProject project) {
-        Trigger trigger = project.getTrigger(StashBuildTrigger.class);
+    public static StashBuildTrigger getTrigger(AbstractProject<?, ?> project) {
+        Trigger<?> trigger = project.getTrigger(StashBuildTrigger.class);
         return (StashBuildTrigger)trigger;
     }
 
@@ -139,32 +123,24 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         Map<String, ParameterValue> values = new HashMap<String, ParameterValue>();
         values.put("sourceBranch", new StringParameterValue("sourceBranch", cause.getSourceBranch()));
         values.put("targetBranch", new StringParameterValue("targetBranch", cause.getTargetBranch()));
+        values.put("pullRequest", new StringParameterValue("pullRequest", cause.getPullRequestBranch()));
         values.put("projectCode", new StringParameterValue("projectCode", cause.getRepositoryOwner()));
         values.put("repositoryName", new StringParameterValue("repositoryName", cause.getRepositoryName()));
         values.put("pullRequestId", new StringParameterValue("pullRequestId", cause.getPullRequestId()));
         values.put("destinationRepositoryOwner", new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
         values.put("destinationRepositoryName", new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));
         values.put("pullRequestTitle", new StringParameterValue("pullRequestTitle", cause.getPullRequestTitle()));
-        return this.job.scheduleBuild2(0, cause, new ParametersAction(new ArrayList(values.values())));
-    }
-
-    private Map<String, ParameterValue> getDefaultParameters() {
-        Map<String, ParameterValue> values = new HashMap<String, ParameterValue>();
-        ParametersDefinitionProperty definitionProperty = this.job.getProperty(ParametersDefinitionProperty.class);
-
-        if (definitionProperty != null) {
-            for (ParameterDefinition definition : definitionProperty.getParameterDefinitions()) {
-                values.put(definition.getName(), definition.getDefaultParameterValue());
-            }
-        }
-        return values;
+        return this.job.scheduleBuild2(0, cause, new ParametersAction(new ArrayList<ParameterValue>(values.values())));
     }
 
     @Override
     public void run() {
-        if(this.getBuilder().getProject().isDisabled()) {
+    	if(this.getBuilder().getProject().isDisabled()) {
             logger.info("Build Skip.");
         } else {
+        	if (!(this.getBuilder().getProject().getScm() instanceof GitSCM))
+        		throw new IllegalStateException("No git SCM defined");
+        	
             this.stashPullRequestsBuilder.run();
         }
         this.getDescriptor().save();

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -120,17 +120,18 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     }
 
     public QueueTaskFuture<?> startJob(StashCause cause) {
-        Map<String, ParameterValue> values = new HashMap<String, ParameterValue>();
-        values.put("sourceBranch", new StringParameterValue("sourceBranch", cause.getSourceBranch()));
-        values.put("targetBranch", new StringParameterValue("targetBranch", cause.getTargetBranch()));
-        values.put("pullRequest", new StringParameterValue("pullRequest", cause.getPullRequestBranch()));
-        values.put("projectCode", new StringParameterValue("projectCode", cause.getRepositoryOwner()));
-        values.put("repositoryName", new StringParameterValue("repositoryName", cause.getRepositoryName()));
-        values.put("pullRequestId", new StringParameterValue("pullRequestId", cause.getPullRequestId()));
-        values.put("destinationRepositoryOwner", new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
-        values.put("destinationRepositoryName", new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));
-        values.put("pullRequestTitle", new StringParameterValue("pullRequestTitle", cause.getPullRequestTitle()));
-        return this.job.scheduleBuild2(0, cause, new ParametersAction(new ArrayList<ParameterValue>(values.values())));
+    	ArrayList<ParameterValue> parameterList = new ArrayList<ParameterValue>();
+    	parameterList.add(new StringParameterValue("sourceProject", cause.getRepositoryOwner()));
+    	parameterList.add(new StringParameterValue("sourceRepository", cause.getRepositoryName()));
+    	parameterList.add(new StringParameterValue("sourceBranch", cause.getSourceBranch()));
+    	parameterList.add(new StringParameterValue("targetProject", cause.getDestinationRepositoryOwner()));
+    	parameterList.add(new StringParameterValue("targetRepository", cause.getDestinationRepositoryName()));
+    	parameterList.add(new StringParameterValue("targetBranch", cause.getTargetBranch()));
+    	parameterList.add(new StringParameterValue("pullRequest", cause.getPullRequestBranch()));
+        parameterList.add(new StringParameterValue("pullRequestId", cause.getPullRequestId()));
+    	parameterList.add(new StringParameterValue("pullRequestTitle", cause.getPullRequestTitle()));
+    	parameterList.add(new StringParameterValue("pullRequestCommit", cause.getSourceCommitHash()));
+    	return this.job.scheduleBuild2(0, cause, new ParametersAction(parameterList));
     }
 
     @Override

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
@@ -8,6 +8,7 @@ import hudson.model.Cause;
 public class StashCause extends Cause {
     private final String sourceBranch;
     private final String targetBranch;
+    private final String pullRequestBranch;
     private final String repositoryOwner;
     private final String repositoryName;
     private final String pullRequestId;
@@ -22,6 +23,7 @@ public class StashCause extends Cause {
     public StashCause(String stashHost,
                           String sourceBranch,
                           String targetBranch,
+                          String pullRequestBranch,
                           String repositoryOwner,
                           String repositoryName,
                           String pullRequestId,
@@ -33,6 +35,7 @@ public class StashCause extends Cause {
                           String buildStartCommentId) {
         this.sourceBranch = sourceBranch;
         this.targetBranch = targetBranch;
+        this.pullRequestBranch = pullRequestBranch;
         this.repositoryOwner = repositoryOwner;
         this.repositoryName = repositoryName;
         this.pullRequestId = pullRequestId;
@@ -52,7 +55,11 @@ public class StashCause extends Cause {
         return targetBranch;
     }
 
-    public String getRepositoryOwner() {
+    public String getPullRequestBranch() {
+		return pullRequestBranch;
+	}
+
+	public String getRepositoryOwner() {
         return repositoryOwner;
     }
 
@@ -87,7 +94,7 @@ public class StashCause extends Cause {
     public String getShortDescription() {
         return "<a href=\"" + stashHost + "/projects/" + this.getDestinationRepositoryOwner() + "/repos/" +
                 this.getDestinationRepositoryName() + "/pull-requests/" + this.getPullRequestId() +
-                "\" >PR #" + this.getPullRequestId() + " " + this.getPullRequestTitle() + " </a>";
+                "/overview\" >PR #" + this.getPullRequestId() + " " + this.getPullRequestTitle() + " </a>";
     }
 }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -25,7 +25,7 @@ public class StashPullRequestsBuilder {
     }
 
     public void run() {
-        logger.info("Build Start.");
+        logger.info("Build for " + project.getDisplayName() + " started");
         this.repository.init();
         Collection<StashPullRequestResponseValue> targetPullRequests = this.repository.getTargetPullRequests();
         this.repository.addFutureBuildTasks(targetPullRequests);
@@ -35,7 +35,7 @@ public class StashPullRequestsBuilder {
         if (this.project == null || this.trigger == null) {
             throw new IllegalStateException();
         }
-        this.repository = new StashRepository(this.trigger.getProjectPath(), this);
+        this.repository = new StashRepository(this);
         this.builds = new StashBuilds(this.trigger, this.repository);
         return this;
     }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -5,7 +5,18 @@ import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestCom
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestMergableResponse;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValueRepository;
+import hudson.EnvVars;
+import hudson.model.Environment;
+import hudson.model.Hudson;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.impl.PreBuildMerge;
+import hudson.security.ACL;
+import hudson.slaves.NodeProperty;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -13,6 +24,15 @@ import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jgit.transport.URIish;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 
 /**
  * Created by Nathan McCarthy
@@ -32,29 +52,86 @@ public class StashRepository {
     public static final String BUILD_FAILURE_COMMENT = "✕ BUILD FAILURE";
     public static final String BUILD_RUNNING_COMMENT = "BUILD RUNNING...";
 
-    private String projectPath;
     private StashPullRequestsBuilder builder;
+    private String targetBranchFilter;
     private StashBuildTrigger trigger;
     private StashApiClient client;
 
-    public StashRepository(String projectPath, StashPullRequestsBuilder builder) {
-        this.projectPath = projectPath;
+    public StashRepository(StashPullRequestsBuilder builder) {
         this.builder = builder;
     }
 
     public void init() {
         trigger = this.builder.getTrigger();
-        client = new StashApiClient(
-                trigger.getStashHost(),
-                trigger.getUsername(),
-                trigger.getPassword(),
-                trigger.getProjectCode(),
-                trigger.getRepositoryName());
+        
+        URIish uri = null;
+        StandardUsernamePasswordCredentials credentials = null;
+        if (StringUtils.isNotBlank(trigger.getTargetBranchFilter()))
+        	targetBranchFilter = trigger.getTargetBranchFilter(); 
+        
+        if (this.builder.getProject().getScm() instanceof GitSCM) {
+        	GitSCM scm = (GitSCM) this.builder.getProject().getScm();
+        	
+        	// retrieve environment variables (so they can be used in hostname)
+        	EnvVars env = new EnvVars(System.getenv());
+    		for (NodeProperty<?> nodeProperty: Hudson.getInstance().getGlobalNodeProperties()) {
+				try {
+					Environment environment = nodeProperty.setUp(null, null, null);
+	                if (environment != null) {
+	                    environment.buildEnvVars(env);
+	                }
+				} catch (IOException e) {
+					e.printStackTrace();
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+            }
+
+    		// resolve environment variables against each other
+            EnvVars.resolve(env);
+        	
+            // TODO: add support for multiple repositories
+            if (scm.getUserRemoteConfigs().size() > 0) {
+            	UserRemoteConfig config = scm.getUserRemoteConfigs().get(0);
+            	try {
+	            	// retrieve host && expand using previously searched environment variables
+	            	uri = new URIish(env.expand(config.getUrl()));
+				} catch (URISyntaxException e) {
+					throw new IllegalStateException("invalid stash uri", e);
+				}
+            	
+            	// get target branch if option is selected and isn't overridden by trigger configuration
+            	if (trigger.isCheckMergeBeforeBuild() && StringUtils.isBlank(trigger.getTargetBranchFilter())) {
+	        		for (GitSCMExtension extension : scm.getExtensions().toList()) {
+	        			if (extension instanceof PreBuildMerge) {
+	        				PreBuildMerge preBuildMerge = (PreBuildMerge) extension;
+	        				targetBranchFilter = env.expand(preBuildMerge.getOptions().getMergeTarget());
+	        				break;
+	        			}
+	        		}
+            	}
+            	
+            	// set credentials
+                if (config.getCredentialsId() != null) {
+                	credentials = CredentialsMatchers.firstOrNull(
+                    		CredentialsProvider.lookupCredentials(
+                    				StandardUsernamePasswordCredentials.class, this.builder.getProject(),
+                    				ACL.SYSTEM, URIRequirementBuilder.fromUri(uri.toString()).build()
+                    		), CredentialsMatchers.allOf(
+                    				CredentialsMatchers.withId(config.getCredentialsId()), GitClient.CREDENTIALS_MATCHER
+                    		)
+                    );
+                }
+            }
+        }
+        
+        client = new StashApiClient(uri, credentials);
     }
 
     public Collection<StashPullRequestResponseValue> getTargetPullRequests() {
-        logger.info("Fetch PullRequests.");
+        logger.info("Fetching pull requests ...");
         List<StashPullRequestResponseValue> pullRequests = client.getPullRequests();
+        logger.info("Found " + pullRequests.size() + " pull requests");
         List<StashPullRequestResponseValue> targetPullRequests = new ArrayList<StashPullRequestResponseValue>();
         for(StashPullRequestResponseValue pullRequest : pullRequests) {
             if (isBuildTarget(pullRequest)) {
@@ -76,9 +153,10 @@ public class StashRepository {
         for(StashPullRequestResponseValue pullRequest : pullRequests) {
             String commentId = postBuildStartCommentTo(pullRequest);
             StashCause cause = new StashCause(
-                    trigger.getStashHost(),
+                    client.getHost(),
                     pullRequest.getFromRef().getBranch().getName(),
                     pullRequest.getToRef().getBranch().getName(),
+                    "*/pr/" + pullRequest.getId() + "/from",
                     pullRequest.getFromRef().getRepository().getProjectName(),
                     pullRequest.getFromRef().getRepository().getRepositoryName(),
                     pullRequest.getId(),
@@ -123,12 +201,18 @@ public class StashRepository {
     private boolean isBuildTarget(StashPullRequestResponseValue pullRequest) {
 
         boolean shouldBuild = true;
-
+        logger.fine("Verifying " + pullRequest);
         if (pullRequest.getState() != null && pullRequest.getState().equals("OPEN")) {
             if (isSkipBuild(pullRequest.getTitle())) {
                 return false;
             }
-
+            
+            if(!isAllowedTargetBranch(pullRequest.getToRef().getBranch().getName())) {
+            	logger.info("skipping trigger, " + pullRequest.getToRef().getBranch().getName() + 
+            			" doesn't match " + targetBranchFilter);
+            	return false;
+            }
+            
             if(!isPullRequestMergable(pullRequest)) {
                 return false;
             }
@@ -210,6 +294,13 @@ public class StashRepository {
             }
         }
         return false;
+    }
+
+    private boolean isAllowedTargetBranch(String pullRequestToBranch) {
+        if (StringUtils.isNotBlank(targetBranchFilter)) {
+        	return pullRequestToBranch.matches(targetBranchFilter);
+        }
+        return true;
     }
 
     private boolean isPhrasesContain(String text, String phrase) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValue.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValue.java
@@ -114,4 +114,17 @@ public class StashPullRequestResponseValue {
         this.id = id;
     }
 
+    @Override
+    public String toString() {
+    	return "pullrequest: " + title + " (#" + id + ")" +
+    			"\n" + "  - to: " + toRef +
+    			"\n" + "  - from: " + fromRef +
+    			"\n" + "  - locked: " + locked +
+    			"\n" + "  - closed: " + closed +
+    			"\n" + "  - state: " + state +
+    			"\n" + "  - createdDate: " + createdDate +
+    			"\n" + "  - updatedDate: " + updatedDate +
+    			"\n" + "  - description: " + description;
+    }
+
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
@@ -105,6 +105,11 @@ public class StashPullRequestResponseValueRepository {
     public void setCommit(StashPullRequestResponseValueRepositoryCommit commit) {
         this.commit = commit;
     }
+    
+    @Override
+    public String toString() {
+    	return branch.getName() + " (id: " + id + ", commit: " + commit.getHash() + ", latestChangeset: " + latestChangeset + ")"; 
+    }
 }
 
 

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -2,36 +2,27 @@
   <f:entry title="Cron" field="cron">
     <f:textbox />
   </f:entry>
-  <f:entry title="Stash Host" field="stashHost">
-      <f:textbox />
-  </f:entry>
-  <f:entry title="Stash BasicAuth Username" field="username">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="Stash BasicAuth Password" field="password">
-    <f:password />
-  </f:entry>
-  <f:entry title="Project" field="projectCode">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="RepositoryName" field="repositoryName">
-    <f:textbox />
-  </f:entry>
   <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
     <f:textbox />
   </f:entry>
   <f:advanced>
+  	<f:entry title="Target branch filter" field="targetBranchFilter">
+      <f:textbox />
+  	</f:entry>
+    <f:entry title="Build only 'Merge before build' target branch?" field="checkMergeBeforeBuild">
+      <f:checkbox checked="true" />
+    </f:entry>
     <f:entry title="Rebuild if destination branch changes?" field="checkDestinationCommit">
       <f:checkbox />
     </f:entry>
     <f:entry title="Build only if Stash reports no conflicts?" field="checkNotConflicted">
-      <f:checkbox default="false"/>
+      <f:checkbox />
     </f:entry>
     <f:entry title="Build only if PR is mergeable?" field="checkMergeable">
-      <f:checkbox default="false"/>
+      <f:checkbox />
     </f:entry>
     <f:entry title="Only build when asked (with test phrase)?" field="onlyBuildOnComment">
-      <f:checkbox default="false"/>
+      <f:checkbox />
     </f:entry>
     <f:entry title="CI Build Phrases" field="ciBuildPhrases">
       <f:textbox default="test this please"/>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkMergeBeforeBuild.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkMergeBeforeBuild.html
@@ -1,0 +1,3 @@
+<div>
+    Only check pull requests where the target branch matches to one provided in the 'Merge before build' extension of GitSCM.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-targetBranchFilter.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-targetBranchFilter.html
@@ -1,0 +1,3 @@
+<div>
+    Provide a regular expression to only check pull requests for specific target branches. Overrules the 'Merge before build' option.
+</div>


### PR DESCRIPTION
Use Git SCM as provider for hostname and credentials needed for the pull request builder.

Now it is also possible to verify pull requests from another fork (while previously it would only work in the same repository, or at least with the merge before build feature). Prerequisite is that you add +refs/pull-requests/*:refs/remotes/origin/pr/* as refspec. 

Additionally you can filter on the target branch which makes you able to restrict checking pull requests on a specific (release) branch.

And last but not least, support for global environment variables has been added.