### PR TITLE
upgrade dependencies to latest version and get build back to green

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.621</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <artifactId>stash-pullrequest-builder</artifactId>
@@ -39,7 +39,7 @@
       <dependency>
           <groupId>org.apache.maven.wagon</groupId>
           <artifactId>wagon-http</artifactId>
-          <version>2.4</version>
+          <version>2.9</version>
       </dependency>
       <dependency>
           <groupId>commons-httpclient</groupId>
@@ -49,7 +49,7 @@
       <dependency>
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
-          <version>1.9</version>
+          <version>1.10</version>
       </dependency>
       <dependency>
           <groupId>org.codehaus.jackson</groupId>
@@ -59,12 +59,12 @@
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>git</artifactId>
-          <version>2.2.4</version>
+          <version>2.4.0</version>
       </dependency>
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>credentials</artifactId>
-          <version>1.21</version>
+          <version>1.22</version>
       </dependency>
   </dependencies>
 
@@ -88,6 +88,15 @@
                     <version>1.9.2</version>
                 </dependency>
             </dependencies>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.3</version>
+            <configuration>
+                <source>1.6</source>
+                <target>1.6</target>
+            </configuration>
         </plugin>
     </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <artifactId>stash-pullrequest-builder</artifactId>
   <name>Stash Pullrequest Builder Plugin</name>
-  <version>1.3.1</version>
+  <version>1.3.2-SNAPSHOT</version>
   <description>This Jenkins plugin builds pull requests from Stash and will report the test results.</description>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Stash+pullrequest+builder+plugin</url>
@@ -17,7 +17,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/stash-pullrequest-builder-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/stash-pullrequest-builder-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/stash-pullrequest-builder-plugin</url>
-      <tag>stash-pullrequest-builder-1.3.1</tag>
+      <tag>HEAD</tag>
   </scm>
   <developers>
     <developer>

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryTest.java
@@ -3,7 +3,7 @@ package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 import org.junit.Before;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test for checking the logic inside the StashPullRequestResponseValueRepository class.


### PR DESCRIPTION
@benkiefer opened up this same [PR](https://github.com/jenkinsci/stash-pullrequest-builder-plugin/pull/7) over on the @jenkinsci fork.