### PR TITLE
Add support to add additional parameters in comments field

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ If you are merging into your target branch, you might want Jenkins to do a new b
 
 If you want to rerun pull request test, write *“test this please”* comment to your pull request.
 
+##Adding additional parameters to a build
+
+If you want to add additional parameters to the triggered build, add comments using the pattern <parametersname>=<value>, one at each line. If the same parametername appears mulitple times the latest comment with that parameter will decide the value.
+
+Example:
+country=USA
+ball=hard
 
 ## Post Build Comment
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ If you want to rerun pull request test, write *“test this please”* comment t
 If you want to add additional parameters to the triggered build, add comments using the pattern <parametersname>=<value>, one at each line. If the same parametername appears mulitple times the latest comment with that parameter will decide the value.
 
 Example:
+
 country=USA
+
 ball=hard
 
 ## Post Build Comment

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -145,6 +145,14 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         values.put("destinationRepositoryOwner", new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
         values.put("destinationRepositoryName", new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));
         values.put("pullRequestTitle", new StringParameterValue("pullRequestTitle", cause.getPullRequestTitle()));
+        
+        Map<String, String> additionalParameters = cause.getAdditionalParameters();
+        if(additionalParameters != null){
+        	for(String parameter : additionalParameters.keySet()){
+        		values.put(parameter, new StringParameterValue(parameter, additionalParameters.get(parameter)));
+        	}
+        }
+        
         return this.job.scheduleBuild2(0, cause, new ParametersAction(new ArrayList(values.values())));
     }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
@@ -1,5 +1,7 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
+import java.util.Map;
+
 import hudson.model.Cause;
 
 /**
@@ -18,6 +20,7 @@ public class StashCause extends Cause {
     private final String destinationCommitHash;
     private final String buildStartCommentId;
     private final String stashHost;
+    private final Map<String,String> additionalParameters;
 
     public StashCause(String stashHost,
                           String sourceBranch,
@@ -30,7 +33,8 @@ public class StashCause extends Cause {
                           String pullRequestTitle,
                           String sourceCommitHash,
                           String destinationCommitHash,
-                          String buildStartCommentId) {
+                          String buildStartCommentId,
+                          Map<String,String> additionalParameters) {
         this.sourceBranch = sourceBranch;
         this.targetBranch = targetBranch;
         this.repositoryOwner = repositoryOwner;
@@ -43,6 +47,7 @@ public class StashCause extends Cause {
         this.destinationCommitHash = destinationCommitHash;
         this.buildStartCommentId = buildStartCommentId;
         this.stashHost = stashHost.replaceAll("/$", "");
+        this.additionalParameters = additionalParameters;
     }
 
     public String getSourceBranch() {
@@ -83,6 +88,8 @@ public class StashCause extends Cause {
 
     public String getBuildStartCommentId() { return buildStartCommentId; }
 
+    public Map<String,String> getAdditionalParameters() { return additionalParameters; }
+    
     @Override
     public String getShortDescription() {
         return "<a href=\"" + stashHost + "/projects/" + this.getDestinationRepositoryOwner() + "/repos/" +

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/AdditionalParameterRegExTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/AdditionalParameterRegExTest.java
@@ -1,0 +1,68 @@
+package stashpullrequestbuilder.stashpullrequestbuilder.stash;
+
+import java.util.AbstractMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import stashpullrequestbuilder.stashpullrequestbuilder.StashRepository;
+
+/**
+ * Created by nathan on 7/06/2015.
+ */
+public class AdditionalParameterRegExTest {
+
+    @Test
+    public void testSingleParameter() throws Exception {
+    	AbstractMap.SimpleEntry<String,String> test1 = StashRepository.getParameter("customer=Nickesocke");
+    	assert (test1 != null);
+    	assert ("customer".equals(test1.getKey()));
+    	assert ("Nickesocke".equals(test1.getValue()));
+    }
+
+    @Test
+    public void testSpacedParameter() throws Exception {
+    	AbstractMap.SimpleEntry<String,String> test1 = StashRepository.getParameter("customer=Nicke socke#");
+    	assert (test1 != null);
+    	assert ("customer".equals(test1.getKey()));
+    	assert ("Nicke socke#".equals(test1.getValue()));
+    }
+
+    @Test
+    public void testBlankParameter() throws Exception {
+    	AbstractMap.SimpleEntry<String,String> test1 = StashRepository.getParameter("the_blank_parameteR=");
+    	assert (test1 != null);
+    	assert ("the_blank_parameteR".equals(test1.getKey()));
+    	assert ("".equals(test1.getValue()));
+    }
+
+    @Test
+    public void testInvalidParameter() throws Exception {
+    	AbstractMap.SimpleEntry<String,String> test1 = StashRepository.getParameter("if apa=Nickesocke");
+    	assert (test1 == null);
+    	AbstractMap.SimpleEntry<String,String> test2 = StashRepository.getParameter("apa==Nickesocke");
+    	assert (test2 == null);
+    	AbstractMap.SimpleEntry<String,String> test3 = StashRepository.getParameter("I want to make sure that a use of = will not trigger parameter");
+    	assert (test3 == null);
+    	AbstractMap.SimpleEntry<String,String> test4 = StashRepository.getParameter("=nothing");
+    	assert (test4 == null);
+    	AbstractMap.SimpleEntry<String,String> test5 = StashRepository.getParameter("=nothing");
+    	assert (test5 == null);
+   }
+
+    @Test
+    public void testMultipleParameters() throws Exception {
+    	Map<String, String> emptyParameters = StashRepository.getParametersFromContent("");
+    	assert (emptyParameters.isEmpty());
+
+    	Map<String, String> singleParameters = StashRepository.getParametersFromContent("param1=nothing");
+    	assert (singleParameters.size() == 1);
+    	assert (singleParameters.get("param1").equals("nothing"));
+
+    	Map<String, String> multipleParameters = StashRepository.getParametersFromContent("param1=nothing\rparam2=something special\nparam3=\r\r\n\rjumping to conclusions\r\r\n\n");
+    	assert (multipleParameters.size() == 3);
+    	assert (multipleParameters.get("param1").equals("nothing"));
+    	assert (multipleParameters.get("param2").equals("something special"));
+    	assert (multipleParameters.get("param3").equals(""));
+    }
+}


### PR DESCRIPTION
Added support to (optionally) add extra parameters sent to the triggered
build.

Scans comments for pattern "parameter=value" and keep the newest value
for each parameter found.