### PR TITLE
Add options to turn off notifications sent to Stash

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -34,6 +34,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean checkMergeable;
     private final boolean checkNotConflicted;
     private final boolean onlyBuildOnComment;
+    private final boolean reportBuildStartedToStash;
+    private final boolean reportBuildStatusToStash;
 
     transient private StashPullRequestsBuilder stashPullRequestsBuilder;
 
@@ -54,6 +56,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             boolean checkMergeable,
             boolean checkNotConflicted,
             boolean onlyBuildOnComment,
+            boolean reportBuildStartedToStash,
+            boolean reportBuildStatusToStash,
             String ciBuildPhrases
             ) throws ANTLRException {
         super(cron);
@@ -70,6 +74,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.checkMergeable = checkMergeable;
         this.checkNotConflicted = checkNotConflicted;
         this.onlyBuildOnComment = onlyBuildOnComment;
+        this.reportBuildStartedToStash = reportBuildStartedToStash;
+        this.reportBuildStatusToStash = reportBuildStatusToStash;
     }
 
     public String getStashHost() {
@@ -110,6 +116,14 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean getCheckDestinationCommit() {
     	return checkDestinationCommit;
+    }
+
+    public boolean reportBuildStartedToStash() {
+        return reportBuildStartedToStash;
+    }
+
+    public boolean reportBuildStatusToStash() {
+        return reportBuildStatusToStash;
     }
 
     @Override

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -35,6 +35,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean checkNotConflicted;
     private final boolean onlyBuildOnComment;
     private final boolean reportBuildStartedToStash;
+    private final boolean deleteBuildStartedToStash;
     private final boolean reportBuildStatusToStash;
 
     transient private StashPullRequestsBuilder stashPullRequestsBuilder;
@@ -57,6 +58,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             boolean checkNotConflicted,
             boolean onlyBuildOnComment,
             boolean reportBuildStartedToStash,
+            boolean deleteBuildStartedToStash,
             boolean reportBuildStatusToStash,
             String ciBuildPhrases
             ) throws ANTLRException {
@@ -75,6 +77,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.checkNotConflicted = checkNotConflicted;
         this.onlyBuildOnComment = onlyBuildOnComment;
         this.reportBuildStartedToStash = reportBuildStartedToStash;
+        this.deleteBuildStartedToStash = deleteBuildStartedToStash;
         this.reportBuildStatusToStash = reportBuildStatusToStash;
     }
 
@@ -120,6 +123,10 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean reportBuildStartedToStash() {
         return reportBuildStartedToStash;
+    }
+
+    public boolean deleteBuildStartedToStash() {
+        return deleteBuildStartedToStash;
     }
 
     public boolean reportBuildStatusToStash() {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -57,7 +57,7 @@ public class StashBuilds {
         else {
             buildUrl = rootUrl + build.getUrl();
         }
-        if (trigger.reportBuildStartedToStash()) {
+        if (trigger.deleteBuildStartedToStash()) {
             repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
         }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -47,6 +47,7 @@ public class StashBuilds {
         if (cause == null) {
             return;
         }
+
         Result result = build.getResult();
         String rootUrl = Jenkins.getInstance().getRootUrl();
         String buildUrl = "";
@@ -56,7 +57,9 @@ public class StashBuilds {
         else {
             buildUrl = rootUrl + build.getUrl();
         }
-        repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
+        if (trigger.reportBuildStartedToStash()) {
+            repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
+        }
 
         StashPostBuildCommentAction comments = build.getAction(StashPostBuildCommentAction.class);
         String additionalComment = "";
@@ -68,6 +71,8 @@ public class StashBuilds {
             }
         }
 
-        repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(), cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl, build.getNumber(), additionalComment);
+        if (trigger.reportBuildStatusToStash()) {
+            repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(), cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl, build.getNumber(), additionalComment);
+        }
     }
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -65,6 +65,9 @@ public class StashRepository {
     }
 
     public String postBuildStartCommentTo(StashPullRequestResponseValue pullRequest) {
+            if (!this.trigger.reportBuildStartedToStash()) {
+                return "";
+            }
             String sourceCommit = pullRequest.getFromRef().getCommit().getHash();
             String destinationCommit = pullRequest.getToRef().getCommit().getHash();
             String comment = String.format(BUILD_START_MARKER, builder.getProject().getDisplayName(), sourceCommit, destinationCommit);

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -87,6 +87,7 @@ public class StashApiClient {
 
     public void deletePullRequestComment(String pullRequestId, String commentId) {
         String path = pullRequestPath(pullRequestId) + "/comments/" + commentId + "?version=0";
+        logger.log(Level.FINEST, "Deleting comment at " + path);
         deleteRequest(path);
     }
 
@@ -94,6 +95,7 @@ public class StashApiClient {
     public StashPullRequestComment postPullRequestComment(String pullRequestId, String comment) {
         String path = pullRequestPath(pullRequestId) + "/comments";
         try {
+            logger.log(Level.FINEST, "Posting \"" + comment + "\" to " + path);
             String response = postRequest(path,  comment);
             return parseSingleCommentJson(response);
 

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -36,5 +36,11 @@
     <f:entry title="CI Build Phrases" field="ciBuildPhrases">
       <f:textbox default="test this please"/>
     </f:entry>
+    <f:entry title="Report build started to Stash?" field="reportBuildStartedToStash">
+      <f:checkbox default="true"/>
+    </f:entry>
+    <f:entry title="Report build result to Stash?" field="reportBuildStatusToStash">
+      <f:checkbox default="true"/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -39,6 +39,9 @@
     <f:entry title="Report build started to Stash?" field="reportBuildStartedToStash">
       <f:checkbox default="true"/>
     </f:entry>
+    <f:entry title="Report build started to Stash?" field="deleteBuildStartedToStash">
+      <f:checkbox default="true"/>
+    </f:entry>
     <f:entry title="Report build result to Stash?" field="reportBuildStatusToStash">
       <f:checkbox default="true"/>
     </f:entry>


### PR DESCRIPTION
Two configuration options "Report build started to Stash?" and "Report build result to Stash?" which allow some finer control of what messages get sent back to Stash.

https://github.com/nemccarthy/stash-pullrequest-builder-plugin/issues/44