### PR TITLE
Fixed latest Stash Null Pointer Exception

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -65,8 +65,8 @@ public class StashRepository {
     }
 
     public String postBuildStartCommentTo(StashPullRequestResponseValue pullRequest) {
-            String sourceCommit = pullRequest.getFromRef().getCommit().getHash();
-            String destinationCommit = pullRequest.getToRef().getCommit().getHash();
+            String sourceCommit = pullRequest.getFromRef().getLatestCommit();
+            String destinationCommit = pullRequest.getToRef().getLatestCommit();
             String comment = String.format(BUILD_START_MARKER, builder.getProject().getDisplayName(), sourceCommit, destinationCommit);
             StashPullRequestComment commentResponse = this.client.postPullRequestComment(pullRequest.getId(), comment);
             return commentResponse.getCommentId().toString();
@@ -85,8 +85,8 @@ public class StashRepository {
                     pullRequest.getToRef().getRepository().getProjectName(),
                     pullRequest.getToRef().getRepository().getRepositoryName(),
                     pullRequest.getTitle(),
-                    pullRequest.getFromRef().getCommit().getHash(),
-                    pullRequest.getToRef().getCommit().getHash(),
+                    pullRequest.getFromRef().getLatestCommit(),
+                    pullRequest.getToRef().getLatestCommit(),
                     commentId);
             this.builder.getTrigger().startJob(cause);
 
@@ -137,12 +137,12 @@ public class StashRepository {
                 shouldBuild = false;
             }
 
-            String sourceCommit = pullRequest.getFromRef().getCommit().getHash();
+            String sourceCommit = pullRequest.getFromRef().getLatestCommit();
 
             StashPullRequestResponseValueRepository destination = pullRequest.getToRef();
             String owner = destination.getRepository().getProjectName();
             String repositoryName = destination.getRepository().getRepositoryName();
-            String destinationCommit = destination.getCommit().getHash();
+            String destinationCommit = destination.getLatestCommit();
 
             String id = pullRequest.getId();
             List<StashPullRequestComment> comments = client.getPullRequestComments(owner, repositoryName, id);

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
@@ -22,6 +22,7 @@ public class StashPullRequestResponseValueRepository {
 
     private String latestChangeset;
     private String id;
+    private String latestCommit;
 
 
     @JsonProperty("id")
@@ -104,6 +105,14 @@ public class StashPullRequestResponseValueRepository {
 
     public void setCommit(StashPullRequestResponseValueRepositoryCommit commit) {
         this.commit = commit;
+    }
+
+    public String getLatestCommit() {
+        return latestCommit;
+    }
+
+    public void setLatestCommit(String latestCommit) {
+        this.latestCommit = latestCommit;
     }
 }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
@@ -108,6 +108,9 @@ public class StashPullRequestResponseValueRepository {
     }
 
     public String getLatestCommit() {
+        if(commit != null) {
+            return commit.getHash();
+        }
         return latestCommit;
     }
 


### PR DESCRIPTION
With my current Stash instance, I'm getting a NPE

WARNING: stashpullrequestbuilder.stashpullrequestbuilder.StashBuildTrigger.run() failed for hudson.maven.MavenModuleSet@13db3c45[GlobeTrottr_PullRequest]
java.lang.NullPointerException
	at stashpullrequestbuilder.stashpullrequestbuilder.StashRepository.isBuildTarget(StashRepository.java:141)
	at stashpullrequestbuilder.stashpullrequestbuilder.StashRepository.getTargetPullRequests(StashRepository.java:61)
	at stashpullrequestbuilder.stashpullrequestbuilder.StashPullRequestsBuilder.run(StashPullRequestsBuilder.java:30)
	at stashpullrequestbuilder.stashpullrequestbuilder.StashBuildTrigger.run(StashBuildTrigger.java:168)
	at hudson.triggers.Trigger.checkTriggers(Trigger.java:282)
	at hudson.triggers.Trigger$Cron.doRun(Trigger.java:221)
	at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:51)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:304)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:178)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)

This patch fixes the issue for me 