### PR TITLE
Manage history of builds internally to reduce comments sent to Stash

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -1,5 +1,7 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestBuildHistory;
+
 import antlr.ANTLRException;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -50,6 +52,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean reportBuildStatusToStash;
     private final boolean deletePreviousBuildFinishComments;
 
+    public static final StashPullRequestBuildHistory buildHistory = new StashPullRequestBuildHistory();
     transient private StashPullRequestsBuilder stashPullRequestsBuilder;
 
     @Extension
@@ -155,7 +158,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean getReportBuildStartedToStash() {
         return reportBuildStartedToStash;
-    }    
+    }
 
     public boolean getDeleteBuildStartedToStash() {
         return deleteBuildStartedToStash;
@@ -179,7 +182,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             this.stashPullRequestsBuilder = StashPullRequestsBuilder.getBuilder();
             this.stashPullRequestsBuilder.setProject(project);
             this.stashPullRequestsBuilder.setTrigger(this);
-            this.stashPullRequestsBuilder.setupBuilder();
+            this.stashPullRequestsBuilder.setupBuilder(this.buildHistory);
         } catch(IllegalStateException e) {
             logger.log(Level.SEVERE, "Can't start trigger", e);
             return;

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -45,6 +45,9 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean checkMergeable;
     private final boolean checkNotConflicted;
     private final boolean onlyBuildOnComment;
+    private final boolean reportBuildStartedToStash;
+    private final boolean deleteBuildStartedToStash;
+    private final boolean reportBuildStatusToStash;
     private final boolean deletePreviousBuildFinishComments;
 
     transient private StashPullRequestsBuilder stashPullRequestsBuilder;
@@ -66,6 +69,9 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             boolean checkMergeable,
             boolean checkNotConflicted,
             boolean onlyBuildOnComment,
+            boolean reportBuildStartedToStash,
+            boolean deleteBuildStartedToStash,
+            boolean reportBuildStatusToStash,
             String ciBuildPhrases,
             boolean deletePreviousBuildFinishComments,
             String targetBranchesToBuild
@@ -84,6 +90,9 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.checkMergeable = checkMergeable;
         this.checkNotConflicted = checkNotConflicted;
         this.onlyBuildOnComment = onlyBuildOnComment;
+        this.reportBuildStartedToStash = reportBuildStartedToStash;
+        this.deleteBuildStartedToStash = deleteBuildStartedToStash;
+        this.reportBuildStatusToStash = reportBuildStatusToStash;
         this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
         this.targetBranchesToBuild = targetBranchesToBuild;
     }
@@ -142,6 +151,18 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean isIgnoreSsl() {
         return ignoreSsl;
+    }
+
+    public boolean getReportBuildStartedToStash() {
+        return reportBuildStartedToStash;
+    }    
+
+    public boolean getDeleteBuildStartedToStash() {
+        return deleteBuildStartedToStash;
+    }
+
+    public boolean getReportBuildStatusToStash() {
+        return reportBuildStatusToStash;
     }
 
     public boolean getDeletePreviousBuildFinishComments() {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -56,7 +56,9 @@ public class StashBuilds {
         else {
             buildUrl = rootUrl + build.getUrl();
         }
-        repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
+        if (trigger.getDeleteBuildStartedToStash()) {
+            repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
+        }
 
         StashPostBuildCommentAction comments = build.getAction(StashPostBuildCommentAction.class);
         String additionalComment = "";
@@ -68,8 +70,10 @@ public class StashBuilds {
             }
         }
         String duration = build.getDurationString();
-        repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(),
-                cause.getDestinationCommitHash(), result, buildUrl,
-                build.getNumber(), additionalComment, duration);
+        if (trigger.getReportBuildStatusToStash()) {
+            repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(),
+                    cause.getDestinationCommitHash(), result, buildUrl,
+                    build.getNumber(), additionalComment, duration);
+        }
     }
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -1,5 +1,6 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestBuildHistory;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue;
 import hudson.model.AbstractProject;
 
@@ -10,7 +11,7 @@ import java.util.logging.Logger;
  * Created by Nathan McCarthy
  */
 public class StashPullRequestsBuilder {
-    private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
+    private static final Logger logger = Logger.getLogger(StashPullRequestsBuilder.class.getName());
     private AbstractProject<?, ?> project;
     private StashBuildTrigger trigger;
     private StashRepository repository;
@@ -31,11 +32,12 @@ public class StashPullRequestsBuilder {
         this.repository.addFutureBuildTasks(targetPullRequests);
     }
 
-    public StashPullRequestsBuilder setupBuilder() {
+    public StashPullRequestsBuilder setupBuilder(StashPullRequestBuildHistory buildHistory) {
         if (this.project == null || this.trigger == null) {
             throw new IllegalStateException();
         }
-        this.repository = new StashRepository(this.trigger.getProjectPath(), this);
+        this.repository = new StashRepository(this.trigger.getProjectPath(),
+                this, buildHistory);
         this.builds = new StashBuilds(this.trigger, this.repository);
         return this;
     }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -77,6 +77,9 @@ public class StashRepository {
     }
 
     public String postBuildStartCommentTo(StashPullRequestResponseValue pullRequest) {
+            if (!this.trigger.getReportBuildStartedToStash()) {
+                return "";
+            }
             String sourceCommit = pullRequest.getFromRef().getLatestCommit();
             String destinationCommit = pullRequest.getToRef().getLatestCommit();
             String comment = String.format(BUILD_START_MARKER, builder.getProject().getDisplayName(), sourceCommit, destinationCommit);

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -107,6 +107,7 @@ public class StashApiClient {
 
     public void deletePullRequestComment(String pullRequestId, String commentId) {
         String path = pullRequestPath(pullRequestId) + "/comments/" + commentId + "?version=0";
+        logger.log(Level.FINEST, "Deleting comment at " + path);
         deleteRequest(path);
     }
 
@@ -114,6 +115,7 @@ public class StashApiClient {
     public StashPullRequestComment postPullRequestComment(String pullRequestId, String comment) {
         String path = pullRequestPath(pullRequestId) + "/comments";
         try {
+            logger.log(Level.FINEST, "Posting \"" + comment + "\" to " + path);
             String response = postRequest(path, comment);
             return parseSingleCommentJson(response);
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestBuildHistory.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestBuildHistory.java
@@ -1,0 +1,103 @@
+package stashpullrequestbuilder.stashpullrequestbuilder.stash;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author blaffoy
+ */
+public class StashPullRequestBuildHistory implements Serializable {
+    private static final Logger logger = Logger.getLogger(StashPullRequestBuildHistory.class.getName());
+
+    private final HashSet<Merge> mergeTriggerHistory;
+    private final HashSet<Integer> commentTriggerHistory;
+
+    private class Merge {
+        public final String branch;
+        public final String target;
+
+        public Merge(String branch, String target) {
+            this.branch = branch;
+            this.target = target;
+        }
+
+        @Override
+        public String toString() {
+            return "branch: \"" + branch + " ; target: \"" + target + "\"";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof Merge))
+                return false;
+            if (obj == this)
+                return true;
+
+            Merge rhs = (Merge) obj;
+            return branch.equals(rhs.branch) && target.equals(rhs.target);
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 23;
+            int mult = 31;
+            hash = this.branch.hashCode() + hash * mult;
+            hash = this.target.hashCode() + hash * mult;
+            return hash;
+        }
+    }
+
+    public StashPullRequestBuildHistory() {
+        logger.log(Level.INFO, "Setting up new Build History");
+        this.mergeTriggerHistory = new HashSet<Merge>();
+        this.commentTriggerHistory = new HashSet<Integer>();
+    }
+
+    public void saveMergeTrigger(String branchSha, String targetSha) {
+        Merge m = new Merge(branchSha, targetSha);
+        String mth = mergeTriggerHistory.toString();
+        if (mergeHasBeenBuilt(m)) {
+            logger.log(Level.SEVERE, "Merge trigger history already contains {0}", m);
+        } else {
+            mergeTriggerHistory.add(m);
+        }
+    }
+
+    private boolean mergeHasBeenBuilt(Merge m) {
+        return mergeTriggerHistory.contains(m);
+    }
+
+    public boolean mergeHasBeenBuilt(String branchSha, String targetSha) {
+        return mergeTriggerHistory.contains(new Merge(branchSha, targetSha));
+    }
+
+    public void saveCommentTrigger(Integer commentId) {
+        String cth = commentTriggerHistory.toString();
+        if (commentHasBeenBuilt(commentId)) {
+            logger.log(Level.SEVERE, "Comment trigger history already contains {0}", commentId);
+        } else {
+            commentTriggerHistory.add(commentId);
+        }
+    }
+
+    public boolean commentHasBeenBuilt(Integer commentId) {
+        return commentTriggerHistory.contains(commentId);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("Comment Trigger History:\n");
+        sb.append(commentTriggerHistory.toString());
+        sb.append("\n");
+        sb.append("Merge Trigger History:\n");
+        sb.append(mergeTriggerHistory.toString());
+        sb.append("\n");
+
+        return sb.toString();
+    }
+}

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -42,5 +42,14 @@
     <f:entry title="CI Build Phrases" field="ciBuildPhrases">
       <f:textbox default="test this please"/>
     </f:entry>
+    <f:entry title="Report build started to Stash?" field="reportBuildStartedToStash">
+      <f:checkbox default="true"/>
+    </f:entry>
+    <f:entry title="Delete build started to Stash?" field="deleteBuildStartedToStash">
+      <f:checkbox default="true"/>
+    </f:entry>
+    <f:entry title="Report build result to Stash?" field="reportBuildStatusToStash">
+      <f:checkbox default="true"/>
+    </f:entry>
   </f:advanced>
 </j:jelly>


### PR DESCRIPTION
Adds options to disable messages sent to Stash, as normal operation of this plugin results in a large number of automated messages swamping development work.

As the plugin depends on Stash messages to manage state, also added a class to manage history of builds internally. This collects a Set of all merges (branch commit + target commit) and comments (comment ID number) that have triggered a build. If a build has already been triggered for a given PR or comment ID, then it will not be rebuilt.
