### PR TITLE
Allow suppressing commenting on pull requests

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -35,6 +35,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean checkMergeable;
     private final boolean checkNotConflicted;
     private final boolean onlyBuildOnComment;
+    private final boolean suppressComments;
 
     transient private StashPullRequestsBuilder stashPullRequestsBuilder;
 
@@ -56,6 +57,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             boolean checkMergeable,
             boolean checkNotConflicted,
             boolean onlyBuildOnComment,
+            boolean suppressComments,
             String ciBuildPhrases
             ) throws ANTLRException {
         super(cron);
@@ -73,6 +75,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.checkMergeable = checkMergeable;
         this.checkNotConflicted = checkNotConflicted;
         this.onlyBuildOnComment = onlyBuildOnComment;
+        this.suppressComments = suppressComments;
     }
 
     public String getStashHost() {
@@ -201,6 +204,10 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean isOnlyBuildOnComment() {
         return onlyBuildOnComment;
+    }
+
+    public boolean isSuppressComments() {
+        return suppressComments;
     }
 
     public static final class StashBuildTriggerDescriptor extends TriggerDescriptor {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -56,20 +56,22 @@ public class StashBuilds {
         else {
             buildUrl = rootUrl + build.getUrl();
         }
-        repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
+        if (!trigger.isSuppressComments()) {
+            repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
 
-        StashPostBuildCommentAction comments = build.getAction(StashPostBuildCommentAction.class);
-        String additionalComment = "";
-        if(comments != null) {
-            String buildComment = result == Result.SUCCESS ? comments.getBuildSuccessfulComment() : comments.getBuildFailedComment();
+            StashPostBuildCommentAction comments = build.getAction(StashPostBuildCommentAction.class);
+            String additionalComment = "";
+            if (comments != null) {
+                String buildComment = result == Result.SUCCESS ? comments.getBuildSuccessfulComment() : comments.getBuildFailedComment();
 
-            if(buildComment != null && !buildComment.isEmpty()) {
-              additionalComment = "\n\n" + buildComment;
+                if (buildComment != null && !buildComment.isEmpty()) {
+                  additionalComment = "\n\n" + buildComment;
+                }
             }
+            String duration = build.getDurationString();
+            repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(),
+                    cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl,
+                    build.getNumber(), additionalComment, duration);
         }
-        String duration = build.getDurationString();
-        repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(),
-                cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl,
-                build.getNumber(), additionalComment, duration);
     }
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -114,10 +114,9 @@ public class StashRepository {
         List<StashPullRequestComment> comments = client.getPullRequestComments(owner, repositoryName, id);
         if (comments != null) {
             Collections.sort(comments);
-//          Collections.reverse(comments);
 
             Map<String, String> result = new TreeMap<String, String>();
-            
+
             for (StashPullRequestComment comment : comments) {
                 String content = comment.getText();
                 if (content == null || content.isEmpty()) {
@@ -126,7 +125,7 @@ public class StashRepository {
 
                 Map<String,String> parameters = getParametersFromContent(content);
                 for(String key : parameters.keySet()){
-                	result.put(key, parameters.get(key));
+                    result.put(key, parameters.get(key));
                 }
             }
             return result;
@@ -135,9 +134,10 @@ public class StashRepository {
     }
     
     public void addFutureBuildTasks(Collection<StashPullRequestResponseValue> pullRequests) {
-        for(StashPullRequestResponseValue pullRequest : pullRequests) {
+        for (StashPullRequestResponseValue pullRequest : pullRequests) {
         	Map<String, String> additionalParameters = getAdditionalParameters(pullRequest);
-            String commentId = postBuildStartCommentTo(pullRequest);
+            String commentId = trigger.isSuppressComments()
+                ? "" : postBuildStartCommentTo(pullRequest);
             StashCause cause = new StashCause(
                     trigger.getStashHost(),
                     pullRequest.getFromRef().getBranch().getName(),

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -36,6 +36,9 @@
     <f:entry title="Only build when asked (with test phrase)?" field="onlyBuildOnComment">
       <f:checkbox default="false"/>
     </f:entry>
+    <f:entry title="Do not comment on builds when they start and are completed" field="suppressComments">
+      <f:checkbox default="false"/>
+    </f:entry>
     <f:entry title="CI Build Phrases" field="ciBuildPhrases">
       <f:textbox default="test this please"/>
     </f:entry>


### PR DESCRIPTION
Fixes #53. Adds a config to disable the "Build started" and "Build Success"/"Build Failed" comments, along with the removal of the "Build started" comment.

Note that I haven't been able to test this - would appreciate a smoke test. I don't have jenkins set up - could do so if necessary.