### PR TITLE
Source repository variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The plugin makes available to the job the following parameter variables:
 
 Select *Git* then configure:
 
-- **Repository URL**: `git@example.com:${projectCode}/${repositoryName}.git`
-- **Branch Specifier**: `*/${sourceBranch}`
+- **Repository URL**: `git@example.com:/${destinationRepositoryOwner}/${destinationRepositoryName}.git`
+- **Advance -> Refspec**: `+refs/pull-requests/*:refs/remotes/origin/pr/*`
+- **Branch Specifier**: `origin/pr/${pullRequestId}/from`
 
 **Build Triggers**
 
@@ -57,23 +58,15 @@ Select *Stash Pull Request Builder* then configure:
 - Only build when asked (with test phrase)?:
 - CI Build Phrases:
 
-##Merge the Pull Request's Source Branch into the Target Branch Before Building
+##Building the merge of Source Branch into Target Branch
 
-You may want Jenkins to attempt to merge your PR before doing the build -- this way it will find conflicts for you automatically.
+You may want Jenkins to build the merged PR (that is the merge of `sourceBranch` into `targetBranch`) to catch any issues resulting from this. To do this change the Branch Specifier from `origin/pr/${pullRequestId}/from` to `origin/pr/${pullRequestId}/merge`
 
-- Follow the steps above in "Creating a Job"
-- In the "Source Code Management" > "Git" > "Additional Behaviors" section, click "Add" > "Merge Before Building"
-- In "Name of Repository" put `origin` (or, if not using default name, use your remote repository's name.
-  - Note: unlike in the main part of the Git Repository config, you cannot leave this item blank for "default".)
-- In "Branch to merge to" put `${targetBranch}"`
+If you are building the merged PR you probably want Jenkins to do a new build when the target branch changes. There is an advanced option in the build trigger, "Rebuild if destination branch changes?" which enables this.
 
-Note that as long as you don't push these changes to your remote repository, the merge only happens in your local repository.
+You probably also only want to build if the PR was mergeable, and possibly also without conflicts. There are advanced options in the build trigger for both of these.
 
-If you are merging into your target branch, you might want Jenkins to do a new build of the Pull Request when the target branch changes. There is a advanced option in the build trigger, "Rebuild if destination branch changes?" which enables this.
-
-##Notify Stash Instance (StashNotifier plugin)
-
-If you are using the StashNotifier plugin and have enabled the 'Notify Stash Instance' Post-build Action while also enabled 'Merge before build', you need to set `${sourceCommitHash}` as Commit SHA-1.  This will record the build result against the source commit.
+If you are using the [StashNotifier plugin](https://wiki.jenkins-ci.org/display/JENKINS/StashNotifier+Plugin) and have enabled the 'Notify Stash Instance' Post-build Action while building the merged PR, you need to set `${sourceCommitHash}` as Commit SHA-1 to record the build result against the source commit.
 
 ##Rerun test builds
 

--- a/README.md
+++ b/README.md
@@ -6,32 +6,56 @@ Stash Pull Request Builder Plugin
 This Jenkins plugin builds pull requests from a Atlassian Stash server and will report the test results as a comment.
 This plugin was inspired by the GitHub & BitBucket pull request builder plugins.
 
-- Official [Jenkins Plugin Page](https://wiki.jenkins-ci.org/display/JENKINS/Stash+pullrequest+builder+plugin); https://wiki.jenkins-ci.org/display/JENKINS/Stash+pullrequest+builder+plugin
-- See this [blogpost](http://blog.nemccarthy.me/?p=387) for more details; http://blog.nemccarthy.me/?p=387 
+- Official [Jenkins Plugin Page](https://wiki.jenkins-ci.org/display/JENKINS/Stash+pullrequest+builder+plugin)
+- See this [blogpost](http://blog.nemccarthy.me/?p=387) for more details
 
 
 ##Prerequisites
 
 - Jenkins 1.532 or higher.
-- Git Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin
+- [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin)
 
+##Parameter variables
+
+The plugin makes available to the job the following parameter variables:
+- `${sourceBranch}`
+- `${targetBranch}`
+- `${projectCode}`
+- `${repositoryName}`
+- `${pullRequestId}`
+- `${destinationRepositoryOwner}`
+- `${destinationReposotryName}`
+- `${pullRequestTitle}`
+- `${sourceCommitHash}`
 
 ##Creating a Job
 
-- Create a new job
-- Select Git SCM
-- Add Repository URL as bellow
-  - git@myStashHost.com:${projectCode}/${repositoryName}.git
-- In Branch Specifier, type as bellow
-  - */${sourceBranch}
-- Under Build Triggers, check Stash Pull Request Builder
-- In Cron, enter crontab for this job.
-  - e.g. every minute: * * * * *
-- In Stash BasicAuth Username - Stash username like jenkins-buildbot
-- In Stash BasicAuth Password - Jenkins Build Bot password
-- Supply project code (this is the abbreviated project code, e.g. PRJ)
-- Supply Repository Name (e.g. myRepo)
-- Save to preserve your changes
+**Source Code Management**
+
+Select *Git* then configure:
+
+- **Repository URL**: `git@example.com:${projectCode}/${repositoryName}.git`
+- **Branch Specifier**: `*/${sourceBranch}`
+
+**Build Triggers**
+
+Select *Stash Pull Request Builder* then configure:
+
+- **Cron**: must be specified. eg: every 2 minute `H/2 * * * *`
+- **Stash Host**: the *http* or *https* URL of the Stash host (NOT *ssh*). eg: *https://example.com*
+- **Stash BasicAuth Username**: eg: *jenkins-buildbot*
+- **Stash BasicAuth Password**: password for the given Username
+- **Project**: abbreviated project code. eg: *PRJ* or *~user*
+- **RepositoryName**: eg: *Repo*
+- **CI Skip Phrases**: optional. eg: *"Don't test"*
+
+**Advanced options**
+- Ignore ssl certificates:
+- Rebuild if destination branch changes?:
+- Build only if Stash reports no conflicts?:
+- Build only if PR is mergeable?:
+- Only build when asked (with test phrase)?:
+- CI Build Phrases:
 
 ##Merge the Pull Request's Source Branch into the Target Branch Before Building
 
@@ -39,17 +63,17 @@ You may want Jenkins to attempt to merge your PR before doing the build -- this 
 
 - Follow the steps above in "Creating a Job"
 - In the "Source Code Management" > "Git" > "Additional Behaviors" section, click "Add" > "Merge Before Building"
-- In "Name of Repository" put "origin" (or, if not using default name, use your remote repository's name. Note: unlike in the main part of the Git Repository config, you cannot leave this item blank for "default".)
-- In "Branch to merge to" put "${targetBranch}" 
-- Note that as long as you don't push these changes to your remote repository, the merge only happens in your local repository.
+- In "Name of Repository" put `origin` (or, if not using default name, use your remote repository's name.
+  - Note: unlike in the main part of the Git Repository config, you cannot leave this item blank for "default".)
+- In "Branch to merge to" put `${targetBranch}"`
 
+Note that as long as you don't push these changes to your remote repository, the merge only happens in your local repository.
 
-If you are merging into your target branch, you might want Jenkins to do a new build of the Pull Request when the target branch changes.
-- There is a checkbox that says, "Rebuild if destination branch changes?" which enables this check.
+If you are merging into your target branch, you might want Jenkins to do a new build of the Pull Request when the target branch changes. There is a advanced option in the build trigger, "Rebuild if destination branch changes?" which enables this.
 
 ##Notify Stash Instance (StashNotifier plugin)
 
-If you have enabled the 'Notify Stash Instance' Post-build Action and also enabled 'Merge before build', you need to set '${sourceCommitHash}' as Commit SHA-1.  This will record the build result against the source commit.
+If you are using the StashNotifier plugin and have enabled the 'Notify Stash Instance' Post-build Action while also enabled 'Merge before build', you need to set `${sourceCommitHash}` as Commit SHA-1.  This will record the build result against the source commit.
 
 ##Rerun test builds
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This plugin was inspired by the GitHub & BitBucket pull request builder plugins.
 The plugin makes available to the job the following parameter variables:
 - `${sourceBranch}`
 - `${targetBranch}`
-- `${projectCode}`
-- `${repositoryName}`
+- `${sourceRepositoryOwner}`
+- `${sourceRepositoryName}`
 - `${pullRequestId}`
 - `${destinationRepositoryOwner}`
 - `${destinationReposotryName}`

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -146,8 +146,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         Map<String, ParameterValue> values = new HashMap<String, ParameterValue>();
         values.put("sourceBranch", new StringParameterValue("sourceBranch", cause.getSourceBranch()));
         values.put("targetBranch", new StringParameterValue("targetBranch", cause.getTargetBranch()));
-        values.put("projectCode", new StringParameterValue("projectCode", cause.getRepositoryOwner()));
-        values.put("repositoryName", new StringParameterValue("repositoryName", cause.getRepositoryName()));
+        values.put("sourceRepositoryOwner", new StringParameterValue("sourceRepositoryOwner", cause.getSourceRepositoryOwner()));
+        values.put("sourceRepositoryName", new StringParameterValue("sourceRepositoryName", cause.getSourceRepositoryName()));
         values.put("pullRequestId", new StringParameterValue("pullRequestId", cause.getPullRequestId()));
         values.put("destinationRepositoryOwner", new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
         values.put("destinationRepositoryName", new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
@@ -10,8 +10,8 @@ import hudson.model.Cause;
 public class StashCause extends Cause {
     private final String sourceBranch;
     private final String targetBranch;
-    private final String repositoryOwner;
-    private final String repositoryName;
+    private final String sourceRepositoryOwner;
+    private final String sourceRepositoryName;
     private final String pullRequestId;
     private final String destinationRepositoryOwner;
     private final String destinationRepositoryName;
@@ -25,8 +25,8 @@ public class StashCause extends Cause {
     public StashCause(String stashHost,
                           String sourceBranch,
                           String targetBranch,
-                          String repositoryOwner,
-                          String repositoryName,
+                          String sourceRepositoryOwner,
+                          String sourceRepositoryName,
                           String pullRequestId,
                           String destinationRepositoryOwner,
                           String destinationRepositoryName,
@@ -37,8 +37,8 @@ public class StashCause extends Cause {
                           Map<String,String> additionalParameters) {
         this.sourceBranch = sourceBranch;
         this.targetBranch = targetBranch;
-        this.repositoryOwner = repositoryOwner;
-        this.repositoryName = repositoryName;
+        this.sourceRepositoryOwner = sourceRepositoryOwner;
+        this.sourceRepositoryName = sourceRepositoryName;
         this.pullRequestId = pullRequestId;
         this.destinationRepositoryOwner = destinationRepositoryOwner;
         this.destinationRepositoryName = destinationRepositoryName;
@@ -57,12 +57,12 @@ public class StashCause extends Cause {
         return targetBranch;
     }
 
-    public String getRepositoryOwner() {
-        return repositoryOwner;
+    public String getSourceRepositoryOwner() {
+        return sourceRepositoryOwner;
     }
 
-    public String getRepositoryName() {
-        return repositoryName;
+    public String getSourceRepositoryName() {
+        return sourceRepositoryName;
     }
 
     public String getPullRequestId() {


### PR DESCRIPTION
Consistent variable naming

projectCode -> sourceRepositoryOwner
repositoryName -> sourceRepositoryName

to be consistent with the destination variables, and importantly to also differentiate from the trigger configuration parameter 'projectCode'.