### PR TITLE
Use Credentials to store Stash login username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ Select *Stash Pull Request Builder* then configure:
 
 - **Cron**: must be specified. eg: every 2 minute `H/2 * * * *`
 - **Stash Host**: the *http* or *https* URL of the Stash host (NOT *ssh*). eg: *https://example.com*
-- **Stash BasicAuth Username**: eg: *jenkins-buildbot*
-- **Stash BasicAuth Password**: password for the given Username
+- **Stash Credentials**: Select or Add the login username/password for the Stash Host
 - **Project**: abbreviated project code. eg: *PRJ* or *~user*
 - **RepositoryName**: eg: *Repo*
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The plugin makes available to the job the following parameter variables:
 
 Select *Git* then configure:
 
-- **Repository URL**: `git@example.com:${projectCode}/${repositoryName}.git`
-- **Branch Specifier**: `*/${sourceBranch}`
+- **Repository URL**: `git@example.com:/${destinationRepositoryOwner}/${destinationRepositoryName}.git`
+- **Advance -> Refspec**: `+refs/pull-requests/*:refs/remotes/origin/pr/*`
+- **Branch Specifier**: `origin/pr/${pullRequestId}/from`
 
 **Build Triggers**
 
@@ -57,23 +58,15 @@ Select *Stash Pull Request Builder* then configure:
 - Only build when asked (with test phrase)?:
 - CI Build Phrases:
 
-##Merge the Pull Request's Source Branch into the Target Branch Before Building
+##Building the merge of Source Branch into Target Branch
 
-You may want Jenkins to attempt to merge your PR before doing the build -- this way it will find conflicts for you automatically.
+You may want Jenkins to build the merged PR (that is the merge of `sourceBranch` into `targetBranch`) to catch any issues resulting from this. To do this change the Branch Specifier from `origin/pr/${pullRequestId}/from` to `origin/pr/${pullRequestId}/merge`
 
-- Follow the steps above in "Creating a Job"
-- In the "Source Code Management" > "Git" > "Additional Behaviors" section, click "Add" > "Merge Before Building"
-- In "Name of Repository" put `origin` (or, if not using default name, use your remote repository's name.
-  - Note: unlike in the main part of the Git Repository config, you cannot leave this item blank for "default".)
-- In "Branch to merge to" put `${targetBranch}"`
+If you are building the merged PR you probably want Jenkins to do a new build when the target branch changes. There is an advanced option in the build trigger, "Rebuild if destination branch changes?" which enables this.
 
-Note that as long as you don't push these changes to your remote repository, the merge only happens in your local repository.
+You probably also only want to build if the PR was mergeable, and possibly also without conflicts. There are advanced options in the build trigger for both of these.
 
-If you are merging into your target branch, you might want Jenkins to do a new build of the Pull Request when the target branch changes. There is a advanced option in the build trigger, "Rebuild if destination branch changes?" which enables this.
-
-##Notify Stash Instance (StashNotifier plugin)
-
-If you are using the StashNotifier plugin and have enabled the 'Notify Stash Instance' Post-build Action while also enabled 'Merge before build', you need to set `${sourceCommitHash}` as Commit SHA-1.  This will record the build result against the source commit.
+If you are using the [StashNotifier plugin](https://wiki.jenkins-ci.org/display/JENKINS/StashNotifier+Plugin) and have enabled the 'Notify Stash Instance' Post-build Action while building the merged PR, you need to set `${sourceCommitHash}` as Commit SHA-1 to record the build result against the source commit.
 
 ##Rerun test builds
 

--- a/README.md
+++ b/README.md
@@ -6,32 +6,56 @@ Stash Pull Request Builder Plugin
 This Jenkins plugin builds pull requests from a Atlassian Stash server and will report the test results as a comment.
 This plugin was inspired by the GitHub & BitBucket pull request builder plugins.
 
-- Official [Jenkins Plugin Page](https://wiki.jenkins-ci.org/display/JENKINS/Stash+pullrequest+builder+plugin); https://wiki.jenkins-ci.org/display/JENKINS/Stash+pullrequest+builder+plugin
-- See this [blogpost](http://blog.nemccarthy.me/?p=387) for more details; http://blog.nemccarthy.me/?p=387 
+- Official [Jenkins Plugin Page](https://wiki.jenkins-ci.org/display/JENKINS/Stash+pullrequest+builder+plugin)
+- See this [blogpost](http://blog.nemccarthy.me/?p=387) for more details
 
 
 ##Prerequisites
 
 - Jenkins 1.532 or higher.
-- Git Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin
+- [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin)
 
+##Parameter variables
+
+The plugin makes available to the job the following parameter variables:
+- `${sourceBranch}`
+- `${targetBranch}`
+- `${projectCode}`
+- `${repositoryName}`
+- `${pullRequestId}`
+- `${destinationRepositoryOwner}`
+- `${destinationReposotryName}`
+- `${pullRequestTitle}`
+- `${sourceCommitHash}`
 
 ##Creating a Job
 
-- Create a new job
-- Select Git SCM
-- Add Repository URL as bellow
-  - git@myStashHost.com:${projectCode}/${repositoryName}.git
-- In Branch Specifier, type as bellow
-  - */${sourceBranch}
-- Under Build Triggers, check Stash Pull Request Builder
-- In Cron, enter crontab for this job.
-  - e.g. every minute: * * * * *
-- In Stash BasicAuth Username - Stash username like jenkins-buildbot
-- In Stash BasicAuth Password - Jenkins Build Bot password
-- Supply project code (this is the abbreviated project code, e.g. PRJ)
-- Supply Repository Name (e.g. myRepo)
-- Save to preserve your changes
+**Source Code Management**
+
+Select *Git* then configure:
+
+- **Repository URL**: `git@example.com:${projectCode}/${repositoryName}.git`
+- **Branch Specifier**: `*/${sourceBranch}`
+
+**Build Triggers**
+
+Select *Stash Pull Request Builder* then configure:
+
+- **Cron**: must be specified. eg: every 2 minute `H/2 * * * *`
+- **Stash Host**: the *http* or *https* URL of the Stash host (NOT *ssh*). eg: *https://example.com*
+- **Stash BasicAuth Username**: eg: *jenkins-buildbot*
+- **Stash BasicAuth Password**: password for the given Username
+- **Project**: abbreviated project code. eg: *PRJ* or *~user*
+- **RepositoryName**: eg: *Repo*
+- **CI Skip Phrases**: optional. eg: *"Don't test"*
+
+**Advanced options**
+- Ignore ssl certificates:
+- Rebuild if destination branch changes?:
+- Build only if Stash reports no conflicts?:
+- Build only if PR is mergeable?:
+- Only build when asked (with test phrase)?:
+- CI Build Phrases:
 
 ##Merge the Pull Request's Source Branch into the Target Branch Before Building
 
@@ -39,17 +63,17 @@ You may want Jenkins to attempt to merge your PR before doing the build -- this 
 
 - Follow the steps above in "Creating a Job"
 - In the "Source Code Management" > "Git" > "Additional Behaviors" section, click "Add" > "Merge Before Building"
-- In "Name of Repository" put "origin" (or, if not using default name, use your remote repository's name. Note: unlike in the main part of the Git Repository config, you cannot leave this item blank for "default".)
-- In "Branch to merge to" put "${targetBranch}" 
-- Note that as long as you don't push these changes to your remote repository, the merge only happens in your local repository.
+- In "Name of Repository" put `origin` (or, if not using default name, use your remote repository's name.
+  - Note: unlike in the main part of the Git Repository config, you cannot leave this item blank for "default".)
+- In "Branch to merge to" put `${targetBranch}"`
 
+Note that as long as you don't push these changes to your remote repository, the merge only happens in your local repository.
 
-If you are merging into your target branch, you might want Jenkins to do a new build of the Pull Request when the target branch changes.
-- There is a checkbox that says, "Rebuild if destination branch changes?" which enables this check.
+If you are merging into your target branch, you might want Jenkins to do a new build of the Pull Request when the target branch changes. There is a advanced option in the build trigger, "Rebuild if destination branch changes?" which enables this.
 
 ##Notify Stash Instance (StashNotifier plugin)
 
-If you have enabled the 'Notify Stash Instance' Post-build Action and also enabled 'Merge before build', you need to set '${sourceCommitHash}' as Commit SHA-1.  This will record the build result against the source commit.
+If you are using the StashNotifier plugin and have enabled the 'Notify Stash Instance' Post-build Action while also enabled 'Merge before build', you need to set `${sourceCommitHash}` as Commit SHA-1.  This will record the build result against the source commit.
 
 ##Rerun test builds
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This plugin was inspired by the GitHub & BitBucket pull request builder plugins.
 The plugin makes available to the job the following parameter variables:
 - `${sourceBranch}`
 - `${targetBranch}`
-- `${projectCode}`
-- `${repositoryName}`
+- `${sourceRepositoryOwner}`
+- `${sourceRepositoryName}`
 - `${pullRequestId}`
 - `${destinationRepositoryOwner}`
 - `${destinationReposotryName}`

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ Select *Stash Pull Request Builder* then configure:
 - **Stash BasicAuth Password**: password for the given Username
 - **Project**: abbreviated project code. eg: *PRJ* or *~user*
 - **RepositoryName**: eg: *Repo*
-- **CI Skip Phrases**: optional. eg: *"Don't test"*
 
 **Advanced options**
 - Ignore ssl certificates:
-- Rebuild if destination branch changes?:
-- Build only if Stash reports no conflicts?:
-- Build only if PR is mergeable?:
-- Only build when asked (with test phrase)?:
-- CI Build Phrases:
+- Rebuild if destination branch changes:
+- Build only if Stash reports no conflicts:
+- Build only if PR is mergeable:
+- CI Skip Phrases: default: "NO TEST"
+- Only build when asked (with test phrase):
+- CI Build Phrases: default: "test this please"
 
 ##Building the merge of Source Branch into Target Branch
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -146,8 +146,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         Map<String, ParameterValue> values = new HashMap<String, ParameterValue>();
         values.put("sourceBranch", new StringParameterValue("sourceBranch", cause.getSourceBranch()));
         values.put("targetBranch", new StringParameterValue("targetBranch", cause.getTargetBranch()));
-        values.put("projectCode", new StringParameterValue("projectCode", cause.getRepositoryOwner()));
-        values.put("repositoryName", new StringParameterValue("repositoryName", cause.getRepositoryName()));
+        values.put("sourceRepositoryOwner", new StringParameterValue("sourceRepositoryOwner", cause.getSourceRepositoryOwner()));
+        values.put("sourceRepositoryName", new StringParameterValue("sourceRepositoryName", cause.getSourceRepositoryName()));
         values.put("pullRequestId", new StringParameterValue("pullRequestId", cause.getPullRequestId()));
         values.put("destinationRepositoryOwner", new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
         values.put("destinationRepositoryName", new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -1,13 +1,23 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
 import antlr.ANTLRException;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.Extension;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
+import hudson.security.ACL;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
+import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.util.ArrayList;
@@ -24,8 +34,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String projectPath;
     private final String cron;
     private final String stashHost;
-    private final String username;
-    private final String password;
+    private final String credentialsId;
     private final String projectCode;
     private final String repositoryName;
     private final String ciSkipPhrases;
@@ -46,8 +55,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             String projectPath,
             String cron,
             String stashHost,
-            String username,
-            String password,
+            String credentialsId,
             String projectCode,
             String repositoryName,
             String ciSkipPhrases,
@@ -62,8 +70,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.projectPath = projectPath;
         this.cron = cron;
         this.stashHost = stashHost;
-        this.username = username;
-        this.password = password;
+        this.credentialsId = credentialsId;
         this.projectCode = projectCode;
         this.repositoryName = repositoryName;
         this.ciSkipPhrases = ciSkipPhrases;
@@ -87,12 +94,24 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         return this.cron;
     }
 
+    // Needed for Jelly Config
+    public String getcredentialsId() {
+    	return this.credentialsId;
+    }
+
+    private StandardUsernamePasswordCredentials getCredentials() {
+        return CredentialsMatchers.firstOrNull(
+                          CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, this.job, ACL.SYSTEM,
+                                                                URIRequirementBuilder.fromUri(stashHost).build()),
+                          CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId)));
+    }
+
     public String getUsername() {
-        return username;
+        return this.getCredentials().getUsername();
     }
 
     public String getPassword() {
-        return password;
+        return this.getCredentials().getPassword().getPlainText();
     }
 
     public String getProjectCode() {
@@ -222,6 +241,14 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             save();
             return super.configure(req, json);
+        }
+
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context, @QueryParameter String source) {
+            if (context == null || !context.hasPermission(Item.CONFIGURE)) {
+                return new ListBoxModel();
+            }
+            return new StandardUsernameListBoxModel().withEmptySelection().withAll(
+               CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, context, ACL.SYSTEM, URIRequirementBuilder.fromUri(source).build()));
         }
     }
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
@@ -10,8 +10,8 @@ import hudson.model.Cause;
 public class StashCause extends Cause {
     private final String sourceBranch;
     private final String targetBranch;
-    private final String repositoryOwner;
-    private final String repositoryName;
+    private final String sourceRepositoryOwner;
+    private final String sourceRepositoryName;
     private final String pullRequestId;
     private final String destinationRepositoryOwner;
     private final String destinationRepositoryName;
@@ -25,8 +25,8 @@ public class StashCause extends Cause {
     public StashCause(String stashHost,
                           String sourceBranch,
                           String targetBranch,
-                          String repositoryOwner,
-                          String repositoryName,
+                          String sourceRepositoryOwner,
+                          String sourceRepositoryName,
                           String pullRequestId,
                           String destinationRepositoryOwner,
                           String destinationRepositoryName,
@@ -37,8 +37,8 @@ public class StashCause extends Cause {
                           Map<String,String> additionalParameters) {
         this.sourceBranch = sourceBranch;
         this.targetBranch = targetBranch;
-        this.repositoryOwner = repositoryOwner;
-        this.repositoryName = repositoryName;
+        this.sourceRepositoryOwner = sourceRepositoryOwner;
+        this.sourceRepositoryName = sourceRepositoryName;
         this.pullRequestId = pullRequestId;
         this.destinationRepositoryOwner = destinationRepositoryOwner;
         this.destinationRepositoryName = destinationRepositoryName;
@@ -57,12 +57,12 @@ public class StashCause extends Cause {
         return targetBranch;
     }
 
-    public String getRepositoryOwner() {
-        return repositoryOwner;
+    public String getSourceRepositoryOwner() {
+        return sourceRepositoryOwner;
     }
 
-    public String getRepositoryName() {
-        return repositoryName;
+    public String getSourceRepositoryName() {
+        return sourceRepositoryName;
     }
 
     public String getPullRequestId() {

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -14,26 +14,26 @@
   <f:entry title="Project" field="projectCode">
     <f:textbox />
   </f:entry>
-  <f:entry title="RepositoryName" field="repositoryName">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
+  <f:entry title="Repository Name" field="repositoryName">
     <f:textbox />
   </f:entry>
   <f:advanced>
-    <f:entry title="Ignore ssl certificates?" field="ignoreSsl">
+    <f:entry title="Ignore ssl certificates" field="ignoreSsl">
       <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="Rebuild if destination branch changes?" field="checkDestinationCommit">
+    <f:entry title="Rebuild if destination branch changes" field="checkDestinationCommit">
       <f:checkbox />
     </f:entry>
-    <f:entry title="Build only if Stash reports no conflicts?" field="checkNotConflicted">
+    <f:entry title="Build only if Stash reports no conflicts" field="checkNotConflicted">
       <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="Build only if PR is mergeable?" field="checkMergeable">
+    <f:entry title="Build only if PR is mergeable" field="checkMergeable">
       <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="Only build when asked (with test phrase)?" field="onlyBuildOnComment">
+        <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
+      <f:textbox default="NO TEST" />
+    </f:entry>
+    <f:entry title="Only build when asked (with test phrase)" field="onlyBuildOnComment">
       <f:checkbox default="false"/>
     </f:entry>
     <f:entry title="CI Build Phrases" field="ciBuildPhrases">

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -1,15 +1,12 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="Cron" field="cron">
     <f:textbox />
   </f:entry>
   <f:entry title="Stash Host" field="stashHost">
       <f:textbox />
   </f:entry>
-  <f:entry title="Stash BasicAuth Username" field="username">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="Stash BasicAuth Password" field="password">
-    <f:password />
+  <f:entry title="Stash Credentials" field="credentialsId">
+    <c:select />
   </f:entry>
   <f:entry title="Project" field="projectCode">
     <f:textbox />


### PR DESCRIPTION
Just as the title says :-)
StashBuildTrigger class now keeps a Jenkins Credentials Object instead of Username and Password, with this exposed in the config.jelly GUI using the appropriate Jelly expected Getters and doFillCredentialsIdItems methods.
Tested, and works fine in my setup, with credentials listed, and the configured one remembered.