### PR TITLE
Allow deleting old build finish comments

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -44,6 +44,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean checkMergeable;
     private final boolean checkNotConflicted;
     private final boolean onlyBuildOnComment;
+    private final boolean deletePreviousBuildFinishComments;
 
     transient private StashPullRequestsBuilder stashPullRequestsBuilder;
 
@@ -64,7 +65,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             boolean checkMergeable,
             boolean checkNotConflicted,
             boolean onlyBuildOnComment,
-            String ciBuildPhrases
+            String ciBuildPhrases,
+            boolean deletePreviousBuildFinishComments
             ) throws ANTLRException {
         super(cron);
         this.projectPath = projectPath;
@@ -80,6 +82,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.checkMergeable = checkMergeable;
         this.checkNotConflicted = checkNotConflicted;
         this.onlyBuildOnComment = onlyBuildOnComment;
+        this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
     }
 
     public String getStashHost() {
@@ -136,6 +139,10 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean isIgnoreSsl() {
         return ignoreSsl;
+    }
+
+    public boolean getDeletePreviousBuildFinishComments() {
+        return deletePreviousBuildFinishComments;
     }
 
     @Override

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -137,7 +137,9 @@ public class StashRepository {
     public void addFutureBuildTasks(Collection<StashPullRequestResponseValue> pullRequests) {
         for(StashPullRequestResponseValue pullRequest : pullRequests) {
         	Map<String, String> additionalParameters = getAdditionalParameters(pullRequest);
-            deletePreviousBuildFinishedComments(pullRequest);
+                if (trigger.getDeletePreviousBuildFinishComments()) {
+                    deletePreviousBuildFinishedComments(pullRequest);
+                }
             String commentId = postBuildStartCommentTo(pullRequest);
             StashCause cause = new StashCause(
                     trigger.getStashHost(),

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -27,7 +27,10 @@
     <f:entry title="Build only if PR is mergeable" field="checkMergeable">
       <f:checkbox default="false"/>
     </f:entry>
-        <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
+    <f:entry title="Keep PR comment only for most recent Build" field="deletePreviousBuildFinishComments">
+      <f:checkbox default="false"/>
+    </f:entry>
+    <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
       <f:textbox default="NO TEST" />
     </f:entry>
     <f:entry title="Only build when asked (with test phrase)" field="onlyBuildOnComment">


### PR DESCRIPTION
When Pull Request branches, or their target branches, are regularly
updated, it can result in a lot of old Build Finish Comments on the PR,
be they success/failure.
As the only action on PR is to merge it, and this only applies to the most
recent HEAD of the PR and the target branch, users/maintainers are generally
only interested in the Build state of this, and not all the previous
ones. So deleting the old ones, and thus only having the state of the
most recent build cuts down on the noise in the PR comments. It make the PR Builder comment
behave almost like a Build Status as found on Stash Commits.
(aside: it would great if Stash supported Build Status for PR, not just
commits. See https://jira.atlassian.com/browse/BSERV-8165).
Controlled by a config option, that defaults to the existing behaviour.
Tested, and works in my setup. Only the most recent Build Finish message is kept.