### PR TITLE
Allow limiting PR builds to specified target branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Select *Stash Pull Request Builder* then configure:
 
 **Advanced options**
 - Ignore ssl certificates:
+- Build PR targetting only these branches: common separated list of branch names. Blank for all.
 - Rebuild if destination branch changes:
 - Build only if Stash reports no conflicts:
 - Build only if PR is mergeable:

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -44,6 +44,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean checkMergeable;
     private final boolean checkNotConflicted;
     private final boolean onlyBuildOnComment;
+    private final boolean deletePreviousBuildFinishComments;
 
     transient private StashPullRequestsBuilder stashPullRequestsBuilder;
 
@@ -64,7 +65,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             boolean checkMergeable,
             boolean checkNotConflicted,
             boolean onlyBuildOnComment,
-            String ciBuildPhrases
+            String ciBuildPhrases,
+            boolean deletePreviousBuildFinishComments
             ) throws ANTLRException {
         super(cron);
         this.projectPath = projectPath;
@@ -80,6 +82,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.checkMergeable = checkMergeable;
         this.checkNotConflicted = checkNotConflicted;
         this.onlyBuildOnComment = onlyBuildOnComment;
+        this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
     }
 
     public String getStashHost() {
@@ -136,6 +139,10 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean isIgnoreSsl() {
         return ignoreSsl;
+    }
+
+    public boolean getDeletePreviousBuildFinishComments() {
+        return deletePreviousBuildFinishComments;
     }
 
     @Override

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -39,6 +39,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String repositoryName;
     private final String ciSkipPhrases;
     private final String ciBuildPhrases;
+    private final String targetBranchesToBuild;
     private final boolean ignoreSsl;
     private final boolean checkDestinationCommit;
     private final boolean checkMergeable;
@@ -66,7 +67,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             boolean checkNotConflicted,
             boolean onlyBuildOnComment,
             String ciBuildPhrases,
-            boolean deletePreviousBuildFinishComments
+            boolean deletePreviousBuildFinishComments,
+            String targetBranchesToBuild
             ) throws ANTLRException {
         super(cron);
         this.projectPath = projectPath;
@@ -83,6 +85,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.checkNotConflicted = checkNotConflicted;
         this.onlyBuildOnComment = onlyBuildOnComment;
         this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
+        this.targetBranchesToBuild = targetBranchesToBuild;
     }
 
     public String getStashHost() {
@@ -143,6 +146,10 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean getDeletePreviousBuildFinishComments() {
         return deletePreviousBuildFinishComments;
+    }
+
+    public String getTargetBranchesToBuild() {
+        return targetBranchesToBuild;
     }
 
     @Override

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -137,7 +137,9 @@ public class StashRepository {
     public void addFutureBuildTasks(Collection<StashPullRequestResponseValue> pullRequests) {
         for(StashPullRequestResponseValue pullRequest : pullRequests) {
         	Map<String, String> additionalParameters = getAdditionalParameters(pullRequest);
-            deletePreviousBuildFinishedComments(pullRequest);
+                if (trigger.getDeletePreviousBuildFinishComments()) {
+                    deletePreviousBuildFinishedComments(pullRequest);
+                }
             String commentId = postBuildStartCommentTo(pullRequest);
             StashCause cause = new StashCause(
                     trigger.getStashHost(),

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -224,6 +224,10 @@ public class StashRepository {
                 return false;
             }
 
+            if (!isForTargetBranch(pullRequest)) {
+                return false;
+            }
+
             if(!isPullRequestMergable(pullRequest)) {
                 return false;
             }
@@ -292,6 +296,20 @@ public class StashRepository {
             }
         }
         return shouldBuild;
+    }
+
+    private boolean isForTargetBranch(StashPullRequestResponseValue pullRequest) {
+        String targetBranchesToBuild = this.trigger.getTargetBranchesToBuild();
+        if (targetBranchesToBuild !=null && !"".equals(targetBranchesToBuild)) {
+            String[] branches = targetBranchesToBuild.split(",");
+            for(String branch : branches) {
+                if (pullRequest.getToRef().getBranch().getName().equalsIgnoreCase(branch.trim())) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean isSkipBuild(String pullRequestTitle) {

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -27,7 +27,10 @@
     <f:entry title="Build only if PR is mergeable" field="checkMergeable">
       <f:checkbox default="false"/>
     </f:entry>
-        <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
+    <f:entry title="Keep PR comment only for most recent Build" field="deletePreviousBuildFinishComments">
+      <f:checkbox default="false"/>
+    </f:entry>
+    <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
       <f:textbox default="NO TEST" />
     </f:entry>
     <f:entry title="Only build when asked (with test phrase)" field="onlyBuildOnComment">

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -18,6 +18,9 @@
     <f:entry title="Ignore ssl certificates" field="ignoreSsl">
       <f:checkbox default="false"/>
     </f:entry>
+    <f:entry title="Build PR targetting only these branches" field="targetBranchesToBuild">
+      <f:textbox default="" />
+    </f:entry>
     <f:entry title="Rebuild if destination branch changes" field="checkDestinationCommit">
       <f:checkbox />
     </f:entry>


### PR DESCRIPTION
This adds an advanced config option that should allow restricting builds to PR that are targeting specific branches. (my specific use to is to restrict builds only to PR targeting the `master` branch)
Tested with a list of two branches, and PR targeting these and then PR targeting other branches, and it triggered appropriately. Default of no branches given also worked.