### PR TITLE
Include default parameter values in build queue

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -195,6 +195,9 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         	}
         }
 
+        // Make sure to add the default parameter values back in!
+        values.putAll(this.getDefaultParameters());
+
         return this.job.scheduleBuild2(0, cause, new ParametersAction(new ArrayList(values.values())));
     }
 


### PR DESCRIPTION
Default parameter values were not being included in queued builds,
resulting in problems with build scripts which expected those values to
exist.  The getDefaultValues() method was already defined, but unused;
now, it is called and its results added to the parameter Map.