### PR TITLE
Add build status api support

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -71,5 +71,6 @@ public class StashBuilds {
         repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(),
                 cause.getDestinationCommitHash(), result, buildUrl,
                 build.getNumber(), additionalComment, duration);
+        repository.postFinishedBuildStatus(build.getProject().getName(), build.toString(), cause.getSourceCommitHash(), result, buildUrl);
     }
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashCommitBuildState.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashCommitBuildState.java
@@ -1,0 +1,18 @@
+package stashpullrequestbuilder.stashpullrequestbuilder.stash;
+
+public enum StashCommitBuildState {
+
+    SUCCESSFUL("SUCCESSFUL"),
+    FAILED("FAILED"),
+    INPROGRESS("INPROGRESS");
+
+    private String state;
+
+    StashCommitBuildState(String state){
+        this.state = state;
+    }
+
+    public String getState() {
+        return state;
+    }
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashCommitBuildStatus.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashCommitBuildStatus.java
@@ -1,0 +1,62 @@
+package stashpullrequestbuilder.stashpullrequestbuilder.stash;
+
+
+public class StashCommitBuildStatus {
+
+    private StashCommitBuildState state;
+    private String key;
+    private String name;
+    private String url;
+    private String description;
+
+    public StashCommitBuildStatus(StashCommitBuildState state, String key, String name, String url, String description) {
+        this.state = state;
+        this.key = key;
+        this.name = name;
+        this.url = url;
+        this.description = description;
+    }
+
+    public StashCommitBuildState getState() {
+        return state;
+    }
+
+    public void setState(StashCommitBuildState state) {
+        this.state = state;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+
+    
+}


### PR DESCRIPTION
BitBucket Server provides build status API.
API doc: https://developer.atlassian.com/static/rest/bitbucket-server/4.5.1/bitbucket-build-rest.html

By using this API, pullrequest builder can tell BitBucket Server whether the pullrequest pass CI test or not, and BitBucket Server utilize build status to determine to block merge.

\* This PR is same as https://github.com/jenkinsci/stash-pullrequest-builder-plugin/pull/14.
