### PR TITLE
More consistent logging

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -319,6 +319,9 @@ public class StashRepository {
                 }
             }
         }
+        if (shouldBuild) {
+            logger.info("Building PR: " + pullRequest.getId());
+        }
         return shouldBuild;
     }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -357,7 +357,7 @@ public class StashApiClient {
                     StringWriter stringWriter = new StringWriter();
                     IOUtils.copy(responseBodyAsStream, stringWriter, "UTF-8");
                     response = stringWriter.toString();
-                    logger.info("API Request Response: " + response);
+                    logger.log(Level.FINEST, "API Request Response: " + response);
                     
                     return response;
 


### PR DESCRIPTION
Use FINEST, as is used for all other API request. Should keep default
log smaller.
Also log PR builds as well as skips.