### PR TITLE
Quote project name in isBuildTarget regexes

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -280,8 +280,8 @@ public class StashRepository {
                     }
 
                     //These will match any start or finish message -- need to check commits
-                    String project_build_start = format(BUILD_START_REGEX, builder.getProject().getDisplayName());
-                    String project_build_finished = format(BUILD_FINISH_REGEX, builder.getProject().getDisplayName());
+                    String project_build_start = String.format(BUILD_START_REGEX, Pattern.quote(builder.getProject().getDisplayName()));
+                    String project_build_finished = String.format(BUILD_FINISH_REGEX, Pattern.quote(builder.getProject().getDisplayName()));
                     Matcher startMatcher = Pattern.compile(project_build_start, Pattern.CASE_INSENSITIVE).matcher(content);
                     Matcher finishMatcher = Pattern.compile(project_build_finished, Pattern.CASE_INSENSITIVE).matcher(content);
 


### PR DESCRIPTION
The project name being inserted into the regex was not quoted for regex
special characters (parens, brackets, etc.), so e.g. project names
containing parens would break the match and would build every time the
pull request was polled.