### PR TITLE
Changes to how variables are added to the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <artifactId>stash-pullrequest-builder</artifactId>
   <name>Stash Pullrequest Builder Plugin</name>
-  <version>1.5.4-SNAPSHOT</version>
+  <version>1.6.0</version>
   <description>This Jenkins plugin builds pull requests from Stash and will report the test results.</description>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Stash+pullrequest+builder+plugin</url>
@@ -17,7 +17,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/stash-pullrequest-builder-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/stash-pullrequest-builder-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/stash-pullrequest-builder-plugin</url>
-      <tag>HEAD</tag>
+      <tag>stash-pullrequest-builder-1.6.0</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <artifactId>stash-pullrequest-builder</artifactId>
   <name>Stash Pullrequest Builder Plugin</name>
-  <version>1.6.0</version>
+  <version>1.6.1-SNAPSHOT</version>
   <description>This Jenkins plugin builds pull requests from Stash and will report the test results.</description>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Stash+pullrequest+builder+plugin</url>
@@ -17,7 +17,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/stash-pullrequest-builder-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/stash-pullrequest-builder-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/stash-pullrequest-builder-plugin</url>
-      <tag>stash-pullrequest-builder-1.6.0</tag>
+      <tag>HEAD</tag>
   </scm>
   <developers>
     <developer>

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java
@@ -1,0 +1,55 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.*;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.*;
+
+@Extension
+public class StashAditionalParameterEnvironmentContributor extends EnvironmentContributor {
+    private static Set<String> params =
+            new HashSet<String>(Arrays.asList("sourceBranch",
+                    "targetBranch",
+                    "sourceRepositoryOwner",
+                    "sourceRepositoryName",
+                    "pullRequestId",
+                    "destinationRepositoryOwner",
+                    "destinationRepositoryName",
+                    "pullRequestTitle",
+                    "sourceCommitHash",
+                    "destinationCommitHash"));
+
+    @Override
+    public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        StashCause cause = (StashCause) r.getCause(StashCause.class);
+        if (cause == null) {
+            return;
+        }
+        ParametersAction pa = r.getAction(ParametersAction.class);
+        for (String param : params) {
+            addParameter(param, pa, envs);
+        }
+        super.buildEnvironmentFor(r, envs, listener);
+    }
+
+    private static void addParameter(String key,
+                                     ParametersAction pa,
+                                     EnvVars envs) {
+        ParameterValue pv = pa.getParameter(key);
+        if (pv == null || !(pv instanceof StringParameterValue)) {
+            return;
+        }
+        StringParameterValue value = (StringParameterValue) pa.getParameter(key);
+        envs.put(key, getString(value.value, ""));
+    }
+
+    private static String getString(String actual,
+                                    String d) {
+        return actual == null ? d : actual;
+    }
+
+
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -72,7 +72,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             String ciBuildPhrases,
             boolean deletePreviousBuildFinishComments,
             String targetBranchesToBuild
-    ) throws ANTLRException {
+            ) throws ANTLRException {
         super(cron);
         this.projectPath = projectPath;
         this.cron = cron;
@@ -105,14 +105,14 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     // Needed for Jelly Config
     public String getcredentialsId() {
-        return this.credentialsId;
+    	return this.credentialsId;
     }
 
     private StandardUsernamePasswordCredentials getCredentials() {
         return CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, this.job, ACL.SYSTEM,
-                        URIRequirementBuilder.fromUri(stashHost).build()),
-                CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId)));
+                          CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, this.job, ACL.SYSTEM,
+                                                                URIRequirementBuilder.fromUri(stashHost).build()),
+                          CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId)));
     }
 
     public String getUsername() {
@@ -140,7 +140,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     }
 
     public boolean getCheckDestinationCommit() {
-        return checkDestinationCommit;
+    	return checkDestinationCommit;
     }
 
     public boolean isIgnoreSsl() {
@@ -162,7 +162,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             this.stashPullRequestsBuilder.setProject(project);
             this.stashPullRequestsBuilder.setTrigger(this);
             this.stashPullRequestsBuilder.setupBuilder();
-        } catch (IllegalStateException e) {
+        } catch(IllegalStateException e) {
             logger.log(Level.SEVERE, "Can't start trigger", e);
             return;
         }
@@ -171,7 +171,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public static StashBuildTrigger getTrigger(AbstractProject project) {
         Trigger trigger = project.getTrigger(StashBuildTrigger.class);
-        return (StashBuildTrigger) trigger;
+        return (StashBuildTrigger)trigger;
     }
 
     public StashPullRequestsBuilder getBuilder() {
@@ -192,10 +192,10 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         values.add(new StringParameterValue("destinationCommitHash", cause.getDestinationCommitHash()));
 
         Map<String, String> additionalParameters = cause.getAdditionalParameters();
-        if (additionalParameters != null) {
-            for (String parameter : additionalParameters.keySet()) {
-                values.add(new StringParameterValue(parameter, additionalParameters.get(parameter)));
-            }
+        if(additionalParameters != null){
+        	for(String parameter : additionalParameters.keySet()){
+        		values.add(new StringParameterValue(parameter, additionalParameters.get(parameter)));
+        	}
         }
         return this.job.scheduleBuild2(0, cause, new ParametersAction(values));
     }
@@ -213,7 +213,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     @Override
     public void run() {
-        if (this.getBuilder().getProject().isDisabled()) {
+        if(this.getBuilder().getProject().isDisabled()) {
             logger.info(format("Build Skip (%s).", getBuilder().getProject().getName()));
         } else {
             logger.info(format("Build started (%s).", getBuilder().getProject().getName()));
@@ -265,7 +265,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
                 return new ListBoxModel();
             }
             return new StandardUsernameListBoxModel().withEmptySelection().withAll(
-                    CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, context, ACL.SYSTEM, URIRequirementBuilder.fromUri(source).build()));
+               CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, context, ACL.SYSTEM, URIRequirementBuilder.fromUri(source).build()));
         }
     }
 }


### PR DESCRIPTION
Jenkins issue SECURITY-180 added a new security feature that only lets declared variables into the build. This fix rewrites the plugin to use environment contributor which is the proper way to give properties to a build. 

This closes #84 