### PR TITLE
Use JenkinsLocationConfiguration to fetch the root URL

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -4,6 +4,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Result;
 import jenkins.model.Jenkins;
+import jenkins.model.JenkinsLocationConfiguration;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -48,7 +49,8 @@ public class StashBuilds {
             return;
         }
         Result result = build.getResult();
-        String rootUrl = Jenkins.getInstance().getRootUrl();
+        JenkinsLocationConfiguration globalConfig = new JenkinsLocationConfiguration();
+        String rootUrl = globalConfig.getUrl();
         String buildUrl = "";
         if (rootUrl == null) {
             buildUrl = " PLEASE SET JENKINS ROOT URL FROM GLOBAL CONFIGURATION " + build.getUrl();


### PR DESCRIPTION
`Jenkins.getInstance().getRootUrl()` returns `null` despite the URL
being set through the web UI. `JenkinsLocationConfiguration.getUrl()`
returns the correct URL.

Thanks Esteban Angee on StackOverflow:
http://stackoverflow.com/questions/15949946/programatically-access-jenkins-url

Resolves:
https://github.com/nishio-dens/bitbucket-pullrequest-builder-plugin/issues/19