### PR TITLE
SocketTimeout causes rebuilding a PR multiple times

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -6,6 +6,7 @@ import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestRes
 import hudson.model.AbstractProject;
 
 import java.util.Collection;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -28,9 +29,13 @@ public class StashPullRequestsBuilder {
 
     public void run() {
         logger.info(format("Build Start (%s).", project.getName()));
-        this.repository.init();
-        Collection<StashPullRequestResponseValue> targetPullRequests = this.repository.getTargetPullRequests();
-        this.repository.addFutureBuildTasks(targetPullRequests);
+        try {
+            this.repository.init();
+            Collection<StashPullRequestResponseValue> targetPullRequests = this.repository.getTargetPullRequests();
+            this.repository.addFutureBuildTasks(targetPullRequests);
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, format("Build Failed (%s).", project.getName()), e);
+        }
     }
 
     public StashPullRequestsBuilder setupBuilder() {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -8,6 +8,7 @@ import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestMer
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValueRepository;
 
+import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -67,7 +68,7 @@ public class StashRepository {
                 trigger.isIgnoreSsl());
     }
 
-    public Collection<StashPullRequestResponseValue> getTargetPullRequests() {
+    public Collection<StashPullRequestResponseValue> getTargetPullRequests() throws IOException {
         logger.info(format("Fetch PullRequests (%s).", builder.getProject().getName()));
         List<StashPullRequestResponseValue> pullRequests = client.getPullRequests();
         List<StashPullRequestResponseValue> targetPullRequests = new ArrayList<StashPullRequestResponseValue>();
@@ -113,14 +114,14 @@ public class StashRepository {
         return result;
    }
 
-    public Map<String, String> getAdditionalParameters(StashPullRequestResponseValue pullRequest){
+    public Map<String, String> getAdditionalParameters(StashPullRequestResponseValue pullRequest) throws IOException {
         StashPullRequestResponseValueRepository destination = pullRequest.getToRef();
         String owner = destination.getRepository().getProjectName();
         String repositoryName = destination.getRepository().getRepositoryName();
 
         String id = pullRequest.getId();
         List<StashPullRequestComment> comments = client.getPullRequestComments(owner, repositoryName, id);
-        if (comments != null) {
+        if (!comments.isEmpty()) {
             Collections.sort(comments);
 //          Collections.reverse(comments);
 
@@ -142,7 +143,7 @@ public class StashRepository {
         return null;
     }
 
-    public void addFutureBuildTasks(Collection<StashPullRequestResponseValue> pullRequests) {
+    public void addFutureBuildTasks(Collection<StashPullRequestResponseValue> pullRequests) throws IOException {
         for(StashPullRequestResponseValue pullRequest : pullRequests) {
         	Map<String, String> additionalParameters = getAdditionalParameters(pullRequest);
                 if (trigger.getDeletePreviousBuildFinishComments()) {
@@ -215,7 +216,7 @@ public class StashRepository {
         return true;
     }
 
-    private void deletePreviousBuildFinishedComments(StashPullRequestResponseValue pullRequest) {
+    private void deletePreviousBuildFinishedComments(StashPullRequestResponseValue pullRequest) throws IOException {
 
         StashPullRequestResponseValueRepository destination = pullRequest.getToRef();
         String owner = destination.getRepository().getProjectName();
@@ -224,7 +225,7 @@ public class StashRepository {
 
         List<StashPullRequestComment> comments = client.getPullRequestComments(owner, repositoryName, id);
 
-        if (comments != null) {
+        if (!comments.isEmpty()) {
             Collections.sort(comments);
                 Collections.reverse(comments);
                 for (StashPullRequestComment comment : comments) {
@@ -243,7 +244,7 @@ public class StashRepository {
         }
     }
 
-    private boolean isBuildTarget(StashPullRequestResponseValue pullRequest) {
+    private boolean isBuildTarget(StashPullRequestResponseValue pullRequest) throws IOException {
 
         boolean shouldBuild = true;
 
@@ -279,7 +280,7 @@ public class StashRepository {
             String id = pullRequest.getId();
             List<StashPullRequestComment> comments = client.getPullRequestComments(owner, repositoryName, id);
 
-            if (comments != null) {
+            if (!comments.isEmpty()) {
                 Collections.sort(comments);
                 Collections.reverse(comments);
                 for (StashPullRequestComment comment : comments) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -77,50 +77,40 @@ public class StashApiClient {
         }
     }
 
-    public List<StashPullRequestResponseValue> getPullRequests() {
+    public List<StashPullRequestResponseValue> getPullRequests() throws IOException {
         List<StashPullRequestResponseValue> pullRequestResponseValues = new ArrayList<StashPullRequestResponseValue>();
-        try {
-            boolean isLastPage = false;
-            int start = 0;
-            while (!isLastPage) {
-                String response = getRequest(pullRequestsPath(start));
-                StashPullRequestResponse parsedResponse = parsePullRequestJson(response);
-                isLastPage = parsedResponse.getIsLastPage();
-                if (!isLastPage) {
-                    start = parsedResponse.getNextPageStart();
-                }
-                pullRequestResponseValues.addAll(parsedResponse.getPrValues());
+        boolean isLastPage = false;
+        int start = 0;
+        while (!isLastPage) {
+            String response = getRequest(pullRequestsPath(start));
+            StashPullRequestResponse parsedResponse = parsePullRequestJson(response);
+            isLastPage = parsedResponse.getIsLastPage();
+            if (!isLastPage) {
+                start = parsedResponse.getNextPageStart();
             }
-            return pullRequestResponseValues;
-        } catch (IOException e) {
-            logger.log(Level.WARNING, "invalid pull request response.", e);
+            pullRequestResponseValues.addAll(parsedResponse.getPrValues());
         }
-        return Collections.EMPTY_LIST;
+        return pullRequestResponseValues;
     }
 
     public List<StashPullRequestComment> getPullRequestComments(String projectCode, String commentRepositoryName,
-                                                                String pullRequestId) {
+                                                                String pullRequestId) throws IOException {
 
-        try {
-            boolean isLastPage = false;
-            int start = 0;
-            List<StashPullRequestActivityResponse> commentResponses = new ArrayList<StashPullRequestActivityResponse>();
-            while (!isLastPage) {
-                String response = getRequest(
-                        apiBaseUrl + projectCode + "/repos/" + commentRepositoryName + "/pull-requests/" +
-                                pullRequestId + "/activities?start=" + start);
-                StashPullRequestActivityResponse resp = parseCommentJson(response);
-                isLastPage = resp.getIsLastPage();
-                if (!isLastPage) {
-                    start = resp.getNextPageStart();
-                }
-                commentResponses.add(resp);
+        boolean isLastPage = false;
+        int start = 0;
+        List<StashPullRequestActivityResponse> commentResponses = new ArrayList<StashPullRequestActivityResponse>();
+        while (!isLastPage) {
+            String response = getRequest(
+                    apiBaseUrl + projectCode + "/repos/" + commentRepositoryName + "/pull-requests/" +
+                            pullRequestId + "/activities?start=" + start);
+            StashPullRequestActivityResponse resp = parseCommentJson(response);
+            isLastPage = resp.getIsLastPage();
+            if (!isLastPage) {
+                start = resp.getNextPageStart();
             }
-            return extractComments(commentResponses);
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "invalid pull request response.", e);
+            commentResponses.add(resp);
         }
-        return Collections.EMPTY_LIST;
+        return extractComments(commentResponses);
     }
 
     public void deletePullRequestComment(String pullRequestId, String commentId) {


### PR DESCRIPTION
Issue #101: SocketTimeout causes rebuilding a PR multiple times.
If a SocketTimeoutException is thrown while reading any of the comment responses, it will be consumed and an empty list will be returned for the comments. The empty list then triggers the build to run again because the plugin thinks no previous attempts were made.
