### PR TITLE
Update to Apache httpclient 4.5.2. This allows to use proxies settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,11 @@
   </repositories>
 
   <dependencies>
-      <dependency>
-          <groupId>commons-httpclient</groupId>
-          <artifactId>commons-httpclient</artifactId>
-          <version>3.1</version>
-      </dependency>
+    <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.2</version>
+    </dependency>
       <dependency>
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>


### PR DESCRIPTION
Fixes #65 

Update to Apache httpclient 4.5.2.

This allows to use proxies settings defined as Java properties (-DproxyHost, -DproxyPort, -Dhttp.proxyHost, -Dhttps.proxyHost,  -Dhttp.nonProxyHosts, ...)

Tested on Jenkins v1.625.3 and v2.26, Stash v4.0.4.
