### PR TITLE
Add option to disable all build comments to Stash

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -67,6 +67,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     private final boolean mergeOnSuccess;
     private final boolean checkNotConflicted;
     private final boolean onlyBuildOnComment;
+    private final boolean disableBuildComments;
     private final boolean deletePreviousBuildFinishComments;
     private final boolean cancelOutdatedJobsEnabled;
 
@@ -93,7 +94,8 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
             String ciBuildPhrases,
             boolean deletePreviousBuildFinishComments,
             String targetBranchesToBuild,
-            boolean cancelOutdatedJobsEnabled
+            boolean cancelOutdatedJobsEnabled,
+            boolean disableBuildComments
     ) throws ANTLRException {
         super(cron);
         this.projectPath = projectPath;
@@ -113,6 +115,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
         this.onlyBuildOnComment = onlyBuildOnComment;
         this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
         this.targetBranchesToBuild = targetBranchesToBuild;
+        this.disableBuildComments = disableBuildComments;
     }
 
     public String getStashHost() {
@@ -179,6 +182,10 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
         return ignoreSsl;
     }
 
+    public boolean isDisableBuildComments() {
+        return disableBuildComments;
+    }
+
     public boolean getDeletePreviousBuildFinishComments() {
         return deletePreviousBuildFinishComments;
     }
@@ -213,7 +220,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
         if (!(job instanceof ParameterizedJobMixIn.ParameterizedJob)) {
             return null;
         }
-        
+
         ParameterizedJobMixIn.ParameterizedJob pjob = (ParameterizedJobMixIn.ParameterizedJob) job;
 
         Trigger trigger = pjob.getTriggers().get(descriptor);
@@ -248,13 +255,13 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
             cancelPreviousJobsInQueueThatMatch(cause);
             abortRunningJobsThatMatch(cause);
         }
-        
+
         return new ParameterizedJobMixIn() {
             @Override
             protected Job asJob() {
                 return StashBuildTrigger.this.job;
             }
-        }.scheduleBuild2(0, new ParametersAction(values), new CauseAction(cause));        
+        }.scheduleBuild2(0, new ParametersAction(values), new CauseAction(cause));
     }
 
     private void cancelPreviousJobsInQueueThatMatch(@Nonnull StashCause stashCause) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -1,11 +1,13 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
 import antlr.ANTLRException;
+
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Build;
@@ -28,7 +30,9 @@ import hudson.triggers.TriggerDescriptor;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
+
 import net.sf.json.JSONObject;
+
 import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
@@ -38,6 +42,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +57,11 @@ import static java.lang.String.format;
 @SuppressFBWarnings({"WMI_WRONG_MAP_ITERATOR", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"})
 public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
+
+    @Extension
+    public static final StashBuildTriggerDescriptor descriptor = new StashBuildTriggerDescriptor();
+
+    transient private StashPullRequestsBuilder builder;
     private final String projectPath;
     private final String cron;
     private final String stashHost;
@@ -70,11 +80,6 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     private final boolean disableBuildComments;
     private final boolean deletePreviousBuildFinishComments;
     private final boolean cancelOutdatedJobsEnabled;
-
-    transient private StashPullRequestsBuilder stashPullRequestsBuilder;
-
-    @Extension
-    public static final StashBuildTriggerDescriptor descriptor = new StashBuildTriggerDescriptor();
 
     @DataBoundConstructor
     public StashBuildTrigger(
@@ -118,6 +123,139 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
         this.disableBuildComments = disableBuildComments;
     }
 
+    @Override
+    public void start(Job<?, ?> job, boolean newInstance) {
+        try {
+            this.builder = StashPullRequestsBuilder.getBuilder(job, this);
+        } catch (IllegalStateException e) {
+            logger.log(Level.SEVERE, "Cannot start trigger", e);
+            return;
+        }
+        super.start(job, newInstance);
+    }
+
+    public static StashBuildTrigger getTrigger(Job job) {
+        if (!(job instanceof ParameterizedJobMixIn.ParameterizedJob)) {
+            return null;
+        }
+
+        ParameterizedJobMixIn.ParameterizedJob pjob = (ParameterizedJobMixIn.ParameterizedJob) job;
+        Trigger trigger = pjob.getTriggers().get(descriptor);
+        return (StashBuildTrigger) trigger;
+    }
+
+    public QueueTaskFuture<?> startJob(StashCause cause) {
+        if (isCancelOutdatedJobsEnabled()) {
+            cancelPreviousJobsInQueueThatMatch(cause);
+            abortRunningJobsThatMatch(cause);
+        }
+
+        return new ParameterizedJobMixIn() {
+            @Override
+            protected Job asJob() {
+                return StashBuildTrigger.this.job;
+            }
+        }.scheduleBuild2(0, new ParametersAction(getParameters(cause)), new CauseAction(cause));
+    }
+
+    private boolean hasCauseFromTheSamePullRequest(@Nullable List<Cause> causes, @Nullable StashCause pullRequestCause) {
+        if (causes != null && pullRequestCause != null) {
+            for (Cause cause : causes) {
+                if (cause instanceof StashCause) {
+                    StashCause sc = (StashCause) cause;
+                    if (StringUtils.equalsIgnoreCase(sc.getPullRequestId(), pullRequestCause.getPullRequestId()) &&
+                            StringUtils.equalsIgnoreCase(sc.getSourceRepositoryName(), pullRequestCause.getSourceRepositoryName())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private void cancelPreviousJobsInQueueThatMatch(@Nonnull StashCause stashCause) {
+        logger.fine("Looking for queued jobs that match PR ID: " + stashCause.getPullRequestId());
+        Queue queue = Jenkins.getInstance().getQueue();
+        for (Queue.Item item : queue.getItems()) {
+            if (hasCauseFromTheSamePullRequest(item.getCauses(), stashCause)) {
+                logger.info("Canceling item in queue: " + item);
+                queue.cancel(item);
+            }
+        }
+    }
+
+    private void abortRunningJobsThatMatch(@Nonnull StashCause stashCause) {
+        logger.fine("Looking for running jobs that match PR ID: " + stashCause.getPullRequestId());
+        for (Object o : job.getBuilds()) {
+            if (o instanceof Build) {
+                Build build = (Build) o;
+                if (build.isBuilding() && hasCauseFromTheSamePullRequest(build.getCauses(), stashCause)) {
+                    logger.info("Aborting build: " + build + " since PR is outdated");
+                    build.getExecutor().interrupt(Result.ABORTED);
+                }
+            }
+        }
+    }
+
+
+    private List<ParameterValue> getParameters(StashCause cause) {
+        List<ParameterValue> values = getDefaultParameters();
+        values.add(new StringParameterValue("sourceBranch", cause.getSourceBranch()));
+        values.add(new StringParameterValue("targetBranch", cause.getTargetBranch()));
+        values.add(new StringParameterValue("sourceRepositoryOwner", cause.getSourceRepositoryOwner()));
+        values.add(new StringParameterValue("sourceRepositoryName", cause.getSourceRepositoryName()));
+        values.add(new StringParameterValue("pullRequestId", cause.getPullRequestId()));
+        values.add(new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
+        values.add(new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));
+        values.add(new StringParameterValue("pullRequestTitle", cause.getPullRequestTitle()));
+        values.add(new StringParameterValue("sourceCommitHash", cause.getSourceCommitHash()));
+        values.add(new StringParameterValue("destinationCommitHash", cause.getDestinationCommitHash()));
+
+        Map<String, String> additionalParameters = cause.getAdditionalParameters();
+        if (additionalParameters != null) {
+            for (String parameter : additionalParameters.keySet()) {
+                values.add(new StringParameterValue(parameter, additionalParameters.get(parameter)));
+            }
+        }
+
+        return values;
+    }
+
+    private List<ParameterValue> getDefaultParameters() {
+        List<ParameterValue> values = new ArrayList<ParameterValue>();
+        ParametersDefinitionProperty definitionProperty = this.job.getProperty(ParametersDefinitionProperty.class);
+        if (definitionProperty != null) {
+            for (ParameterDefinition definition : definitionProperty.getParameterDefinitions()) {
+                values.add(definition.getDefaultParameterValue());
+            }
+        }
+        return values;
+    }
+
+
+    @Override
+    public void run() {
+        Job job = builder.getJob();
+        if (!job.isBuildable()) {
+            logger.finer(format("%s: Skip analyze.", job.getFullDisplayName()));
+        } else {
+            logger.finer(format("%s: Start analyze", job.getFullDisplayName()));
+            builder.run();
+            logger.finer(format("%s: End analyze", job.getFullDisplayName()));
+        }
+        this.getDescriptor().save();
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+    }
+
+
+    public StashPullRequestsBuilder getBuilder() {
+        return builder;
+    }
+
     public String getStashHost() {
         return stashHost;
     }
@@ -132,22 +270,22 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
 
     // Needed for Jelly Config
     public String getcredentialsId() {
-    	return this.credentialsId;
+        return this.credentialsId;
     }
 
     private StandardUsernamePasswordCredentials getCredentials() {
         Authentication defaultAuth = null;
         if (job instanceof Queue.Task) {
-            defaultAuth = Tasks.getDefaultAuthenticationOf((Queue.Task)this.job);
+            defaultAuth = Tasks.getDefaultAuthenticationOf((Queue.Task) this.job);
         }
         return CredentialsMatchers.firstOrNull(
-                          CredentialsProvider.lookupCredentials(
-                                  StandardUsernamePasswordCredentials.class,
-                                  this.job,
-                                  defaultAuth,
-                                  URIRequirementBuilder.fromUri(stashHost).build()
-                          ),
-                          CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId)));
+                CredentialsProvider.lookupCredentials(
+                        StandardUsernamePasswordCredentials.class,
+                        this.job,
+                        defaultAuth,
+                        URIRequirementBuilder.fromUri(stashHost).build()
+                ),
+                CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId)));
     }
 
     public String getUsername() {
@@ -175,7 +313,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     }
 
     public boolean getCheckDestinationCommit() {
-    	return checkDestinationCommit;
+        return checkDestinationCommit;
     }
 
     public boolean isIgnoreSsl() {
@@ -200,134 +338,6 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
 
     public boolean isCancelOutdatedJobsEnabled() {
         return cancelOutdatedJobsEnabled;
-    }
-
-    @Override
-    public void start(Job<?, ?> job, boolean newInstance) {
-        try {
-            this.stashPullRequestsBuilder = StashPullRequestsBuilder.getBuilder();
-            this.stashPullRequestsBuilder.setJob(job);
-            this.stashPullRequestsBuilder.setTrigger(this);
-            this.stashPullRequestsBuilder.setupBuilder();
-        } catch(IllegalStateException e) {
-            logger.log(Level.SEVERE, "Can't start trigger", e);
-            return;
-        }
-        super.start(job, newInstance);
-    }
-
-    public static StashBuildTrigger getTrigger(Job job) {
-        if (!(job instanceof ParameterizedJobMixIn.ParameterizedJob)) {
-            return null;
-        }
-
-        ParameterizedJobMixIn.ParameterizedJob pjob = (ParameterizedJobMixIn.ParameterizedJob) job;
-
-        Trigger trigger = pjob.getTriggers().get(descriptor);
-        return (StashBuildTrigger)trigger;
-    }
-
-    public StashPullRequestsBuilder getBuilder() {
-        return this.stashPullRequestsBuilder;
-    }
-
-    public QueueTaskFuture<?> startJob(StashCause cause) {
-        List<ParameterValue> values = getDefaultParameters();
-        values.add(new StringParameterValue("sourceBranch", cause.getSourceBranch()));
-        values.add(new StringParameterValue("targetBranch", cause.getTargetBranch()));
-        values.add(new StringParameterValue("sourceRepositoryOwner", cause.getSourceRepositoryOwner()));
-        values.add(new StringParameterValue("sourceRepositoryName", cause.getSourceRepositoryName()));
-        values.add(new StringParameterValue("pullRequestId", cause.getPullRequestId()));
-        values.add(new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
-        values.add(new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));
-        values.add(new StringParameterValue("pullRequestTitle", cause.getPullRequestTitle()));
-        values.add(new StringParameterValue("sourceCommitHash", cause.getSourceCommitHash()));
-        values.add(new StringParameterValue("destinationCommitHash", cause.getDestinationCommitHash()));
-
-        Map<String, String> additionalParameters = cause.getAdditionalParameters();
-        if(additionalParameters != null){
-        	for(String parameter : additionalParameters.keySet()){
-        		values.add(new StringParameterValue(parameter, additionalParameters.get(parameter)));
-        	}
-        }
-
-        if (isCancelOutdatedJobsEnabled()) {
-            cancelPreviousJobsInQueueThatMatch(cause);
-            abortRunningJobsThatMatch(cause);
-        }
-
-        return new ParameterizedJobMixIn() {
-            @Override
-            protected Job asJob() {
-                return StashBuildTrigger.this.job;
-            }
-        }.scheduleBuild2(0, new ParametersAction(values), new CauseAction(cause));
-    }
-
-    private void cancelPreviousJobsInQueueThatMatch(@Nonnull StashCause stashCause) {
-        logger.fine("Looking for queued jobs that match PR ID: " + stashCause.getPullRequestId());
-        Queue queue = Jenkins.getInstance().getQueue();
-        for (Queue.Item item : queue.getItems()) {
-            if (hasCauseFromTheSamePullRequest(item.getCauses(), stashCause)) {
-                logger.info("Canceling item in queue: " + item);
-                queue.cancel(item);
-            }
-        }
-    }
-
-    private void abortRunningJobsThatMatch(@Nonnull StashCause stashCause) {
-        logger.fine("Looking for running jobs that match PR ID: " + stashCause.getPullRequestId());
-        for (Object o : job.getBuilds()) {
-            if (o instanceof Build) {
-                Build build = (Build) o;
-                if (build.isBuilding() && hasCauseFromTheSamePullRequest(build.getCauses(), stashCause)) {
-                    logger.info("Aborting build: " + build + " since PR is outdated");
-                    build.getExecutor().interrupt(Result.ABORTED);
-                }
-            }
-        }
-    }
-
-    private boolean hasCauseFromTheSamePullRequest(@Nullable List<Cause> causes, @Nullable StashCause pullRequestCause) {
-        if (causes != null && pullRequestCause != null) {
-            for (Cause cause : causes) {
-                if (cause instanceof StashCause) {
-                    StashCause sc = (StashCause) cause;
-                    if (StringUtils.equals(sc.getPullRequestId(), pullRequestCause.getPullRequestId()) &&
-                            StringUtils.equals(sc.getSourceRepositoryName(), pullRequestCause.getSourceRepositoryName())) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    private List<ParameterValue> getDefaultParameters() {
-        List<ParameterValue> values = new ArrayList<ParameterValue>();
-        ParametersDefinitionProperty definitionProperty = this.job.getProperty(ParametersDefinitionProperty.class);
-        if (definitionProperty != null) {
-            for (ParameterDefinition definition : definitionProperty.getParameterDefinitions()) {
-                values.add(definition.getDefaultParameterValue());
-            }
-        }
-        return values;
-    }
-
-    @Override
-    public void run() {
-        if(!this.getBuilder().getJob().isBuildable()) {
-            logger.info(format("Build Skip (%s).", getBuilder().getJob().getName()));
-        } else {
-            logger.info(format("Build started (%s).", getBuilder().getJob().getName()));
-            this.stashPullRequestsBuilder.run();
-        }
-        this.getDescriptor().save();
-    }
-
-    @Override
-    public void stop() {
-        super.stop();
     }
 
     public boolean isCheckMergeable() {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
@@ -19,6 +19,7 @@ public class StashCause extends Cause {
     private final String sourceCommitHash;
     private final String destinationCommitHash;
     private final String buildStartCommentId;
+    private final long buildLastTimestamp;
     private final String pullRequestVersion;
     private final String stashHost;
     private final Map<String,String> additionalParameters;
@@ -35,8 +36,10 @@ public class StashCause extends Cause {
                           String sourceCommitHash,
                           String destinationCommitHash,
                           String buildStartCommentId,
+                          long buildLastTimestampId,
                           String pullRequestVersion,
                           Map<String,String> additionalParameters) {
+        this.stashHost = stashHost.replaceAll("/$", "");
         this.sourceBranch = sourceBranch;
         this.targetBranch = targetBranch;
         this.sourceRepositoryOwner = sourceRepositoryOwner;
@@ -48,14 +51,15 @@ public class StashCause extends Cause {
         this.sourceCommitHash = sourceCommitHash;
         this.destinationCommitHash = destinationCommitHash;
         this.buildStartCommentId = buildStartCommentId;
+        this.buildLastTimestamp = buildLastTimestampId;
         this.pullRequestVersion = pullRequestVersion;
-        this.stashHost = stashHost.replaceAll("/$", "");
         this.additionalParameters = additionalParameters;
     }
 
     public String getSourceBranch() {
         return sourceBranch;
     }
+
     public String getTargetBranch() {
         return targetBranch;
     }
@@ -93,6 +97,10 @@ public class StashCause extends Cause {
     public String getDestinationCommitHash() { return destinationCommitHash; }
 
     public String getBuildStartCommentId() { return buildStartCommentId; }
+
+    public long getBuildLastTimestamp() {
+        return buildLastTimestamp;
+    }
 
     public Map<String,String> getAdditionalParameters() { return additionalParameters; }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -1,53 +1,39 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
-import static java.lang.String.format;
-
 import hudson.model.Job;
-import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue;
-
-import java.util.Collection;
-import java.util.logging.Logger;
 
 /**
  * Created by Nathan McCarthy
  */
 public class StashPullRequestsBuilder {
-    private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
     private Job<?, ?> job;
     private StashBuildTrigger trigger;
     private StashRepository repository;
     private StashBuilds builds;
 
-    public static StashPullRequestsBuilder getBuilder() {
-        return new StashPullRequestsBuilder();
+    public static StashPullRequestsBuilder getBuilder(Job<?, ?> job, StashBuildTrigger trigger) {
+        StashPullRequestsBuilder builder = new StashPullRequestsBuilder();
+        builder.job = job;
+        builder.trigger = trigger;
+        return builder.setupBuilder();
+    }
+
+    public void run() {
+        this.repository.init();
+        this.repository.buildPullRequests(this.repository.getBuildablePullRequests());
     }
 
     public void stop() {
         // TODO?
     }
 
-    public void run() {
-        logger.info(format("Build Start (%s).", job.getName()));
-        this.repository.init();
-        Collection<StashPullRequestResponseValue> targetPullRequests = this.repository.getTargetPullRequests();
-        this.repository.addFutureBuildTasks(targetPullRequests);
-    }
-
-    public StashPullRequestsBuilder setupBuilder() {
+    protected StashPullRequestsBuilder setupBuilder() {
         if (this.job == null || this.trigger == null) {
             throw new IllegalStateException();
         }
         this.repository = new StashRepository(this.trigger.getProjectPath(), this);
         this.builds = new StashBuilds(this.trigger, this.repository);
         return this;
-    }
-
-    public void setJob(Job<?, ?> job) {
-        this.job = job;
-    }
-
-    public void setTrigger(StashBuildTrigger trigger) {
-        this.trigger = trigger;
     }
 
     public Job<?, ?> getJob() {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -143,12 +143,15 @@ public class StashRepository {
     }
 
     public void addFutureBuildTasks(Collection<StashPullRequestResponseValue> pullRequests) {
-        for(StashPullRequestResponseValue pullRequest : pullRequests) {
-        	Map<String, String> additionalParameters = getAdditionalParameters(pullRequest);
-                if (trigger.getDeletePreviousBuildFinishComments()) {
-                    deletePreviousBuildFinishedComments(pullRequest);
-                }
-            String commentId = postBuildStartCommentTo(pullRequest);
+        for (StashPullRequestResponseValue pullRequest : pullRequests) {
+            Map<String, String> additionalParameters = getAdditionalParameters(pullRequest);
+            String commentId = null;
+            if (trigger.getDeletePreviousBuildFinishComments()) {
+                deletePreviousBuildFinishedComments(pullRequest);
+            }
+            if (!trigger.isDisableBuildComments()) {
+                commentId = postBuildStartCommentTo(pullRequest);
+            }
             StashCause cause = new StashCause(
                     trigger.getStashHost(),
                     pullRequest.getFromRef().getBranch().getName(),
@@ -165,12 +168,13 @@ public class StashRepository {
                     pullRequest.getVersion(),
                     additionalParameters);
             this.builder.getTrigger().startJob(cause);
-
         }
     }
 
     public void deletePullRequestComment(String pullRequestId, String commentId) {
-        this.client.deletePullRequestComment(pullRequestId, commentId);
+        if (pullRequestId != null && commentId != null) {
+            this.client.deletePullRequestComment(pullRequestId, commentId);
+        }
     }
 
     private String getMessageForBuildResult(Result result) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestActivity.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestActivity.java
@@ -23,15 +23,12 @@ public class StashPullRequestActivity implements Comparable<StashPullRequestActi
         if (this.comment == null || target.getComment() == null) {
             return -1;
         }
-        int commmentIdThis = this.comment.getCommentId();
-        int commmentIdOther = target.getComment().getCommentId();
 
-        if (commmentIdThis > commmentIdOther) {
-            return 1;
-        } else if (commmentIdThis == commmentIdOther) {
-            return 0;
-        } else {
-            return -1;
+        int c0 = Integer.signum(this.comment.getCommentId() - target.getComment().getCommentId());
+        if (c0 != 0) {
+            return c0;
         }
+
+        return Long.signum(this.comment.getCreatedDate() - target.comment.getCreatedDate());
     }
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestComment.java
@@ -13,6 +13,7 @@ public class StashPullRequestComment implements Comparable<StashPullRequestComme
 
     private Integer commentId;//
     private String text;
+    private long createdDate;
 
 
     @JsonProperty("id")
@@ -33,6 +34,13 @@ public class StashPullRequestComment implements Comparable<StashPullRequestComme
         this.text = text;
     }
 
+    public long getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(long createdDate) {
+        this.createdDate = createdDate;
+    }
 
     public int compareTo(StashPullRequestComment target) {
         if (this.getCommentId() > target.getCommentId()) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValue.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValue.java
@@ -1,5 +1,6 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
@@ -26,6 +27,8 @@ public class StashPullRequestResponseValue {
     private String id; //
 
     private String version;
+
+    private long lastActionTimestamp;
 
     public String getDescription() {
         return description;
@@ -119,6 +122,15 @@ public class StashPullRequestResponseValue {
         this.updatedDate = updatedDate;
     }
 
+    @JsonIgnore
+    public long getLastActionTimestamp() {
+        return lastActionTimestamp;
+    }
+
+    @JsonIgnore
+    public void setLastActionTimestamp(long lastActionTimestamp) {
+        this.lastActionTimestamp = lastActionTimestamp;
+    }
 
     public String getId() {
         return id;

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -34,6 +34,9 @@
     <f:entry title="Merge PR if build is successful" field="mergeOnSuccess">
         <f:checkbox default="false"/>
     </f:entry>
+    <f:entry title="Disable build comments" field="disableBuildComments">
+      <f:checkbox default="false"/>
+    </f:entry>
     <f:entry title="Keep PR comment only for most recent Build" field="deletePreviousBuildFinishComments">
       <f:checkbox default="false"/>
     </f:entry>


### PR DESCRIPTION
In some cases, build comments mislead the PR reviewer on BitBucket.
So its nice to have a disable all comments to clarify discussion.

Example case:
Old-style pipelines based on freestyles jobs and using pipeline view plugin. Making a parallel build needs create small steps as different jobs to run, then build status of triggered, first, job does not matches to pipeline build status.