### PR TITLE
Fix issue with Jenkins 2.141 and changes for JENKINS-52818

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -49,8 +49,8 @@ public class StashBuilds {
             return;
         }
         Result result = run.getResult();
-        JenkinsLocationConfiguration globalConfig = new JenkinsLocationConfiguration();
-        String rootUrl = globalConfig.getUrl();
+        JenkinsLocationConfiguration globalConfig = JenkinsLocationConfiguration.get();
+        String rootUrl = globalConfig == null ? null : globalConfig.getUrl();
         String buildUrl = "";
         if (rootUrl == null) {
             buildUrl = " PLEASE SET JENKINS ROOT URL FROM GLOBAL CONFIGURATION " + run.getUrl();


### PR DESCRIPTION
The new logic exposed this incorrect usage from this plugin.
Had to add null guard because this is failing a findbugs test
although the .get() method is marked with @Nonnull annotation in
the Jenkins core class.

This fixes #148 