### PR TITLE
Enable Regex on the Build and SkipBuild Phrases

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -372,7 +372,8 @@ public class StashRepository {
         return false;
     }
 
-    private boolean isPhrasesContain(String text, String phrase) {
-        return text != null && text.toLowerCase().contains(phrase.trim().toLowerCase());
+    /* Using a regex expression rather then only tests */
+    private boolean isPhrasesContain(String text, String regex) {
+        return text != null && Pattern.compile(regex).matcher(text).find();
     }
 }

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -40,13 +40,13 @@
     <f:entry title="Cancel outdated jobs" field="cancelOutdatedJobsEnabled">
       <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
+    <f:entry title="CI Skip Phrases (regex)" field="ciSkipPhrases">
       <f:textbox default="NO TEST" />
     </f:entry>
     <f:entry title="Only build when asked (with test phrase)" field="onlyBuildOnComment">
       <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="CI Build Phrases" field="ciBuildPhrases">
+    <f:entry title="CI Build Phrases (regex)" field="ciBuildPhrases">
       <f:textbox default="test this please"/>
     </f:entry>
   </f:advanced>


### PR DESCRIPTION
* Add regex match support to the function that evaluates the Jenkins
  build and skipBuild phrases to support regex. Using a regular expression
  extends the way of defining the messages on both Pull Requests comments
  and Pull Requests title.