### PR TITLE
Update StashBuilds.java

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -49,7 +49,7 @@ public class StashBuilds {
             return;
         }
         Result result = run.getResult();
-        JenkinsLocationConfiguration globalConfig = new JenkinsLocationConfiguration();
+        JenkinsLocationConfiguration globalConfig = new JenkinsLocationConfiguration().get();
         String rootUrl = globalConfig.getUrl();
         String buildUrl = "";
         if (rootUrl == null) {


### PR DESCRIPTION
Without the `.get()` the subsequent `getUrl()` is returning `null`. I have two instances of Jenkins running two different versions. The older 2.121.2 version works as is here, but the newer 2.150.1 doesn't work without this change. Not sure if the API updated recently?